### PR TITLE
Move `commands.proto` and `events.proto` to the entity package

### DIFF
--- a/model/src/main/proto/spine_examples/shareaware/watchlist/commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/watchlist/commands.proto
@@ -26,7 +26,7 @@
 
 syntax = "proto3";
 
-package spine_examples.shareaware.watchlist.command;
+package spine_examples.shareaware.watchlist;
 
 import "spine/options.proto";
 

--- a/model/src/main/proto/spine_examples/shareaware/watchlist/commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/watchlist/commands.proto
@@ -40,9 +40,9 @@ import "spine_examples/shareaware/identifiers.proto";
 // A command to create a new watchlist.
 message CreateWatchlist {
 
-  // The ID of the watchlist to create.
-  WatchlistId watchlist = 1;
+    // The ID of the watchlist to create.
+    WatchlistId watchlist = 1;
 
-  // The name of the watchlist.
-  string name = 2 [(required) = true];
+    // The name of the watchlist.
+    string name = 2 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/shareaware/watchlist/commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/watchlist/commands.proto
@@ -26,23 +26,23 @@
 
 syntax = "proto3";
 
-package spine_examples.shareaware.event;
+package spine_examples.shareaware.watchlist.command;
 
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.shareaware.spine.io";
-option java_package = "io.spine.examples.shareaware.event";
-option java_outer_classname = "EventsProto";
+option java_package = "io.spine.examples.shareaware.watchlist.command";
+option java_outer_classname = "CommandsProto";
 option java_multiple_files = true;
 
 import "spine_examples/shareaware/identifiers.proto";
 
-// A new watchlist has been created.
-message WatchlistCreated {
+// A command to create a new watchlist.
+message CreateWatchlist {
 
-    // The ID of the created watchlist.
-    WatchlistId watchlist = 1;
+  // The ID of the watchlist to create.
+  WatchlistId watchlist = 1;
 
-    // The name of the created watchlist.
-    string name = 2 [(required) = true];
+  // The name of the watchlist.
+  string name = 2 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/shareaware/watchlist/events.proto
+++ b/model/src/main/proto/spine_examples/shareaware/watchlist/events.proto
@@ -40,9 +40,9 @@ import "spine_examples/shareaware/identifiers.proto";
 // A new watchlist has been created.
 message WatchlistCreated {
 
-  // The ID of the created watchlist.
-  WatchlistId watchlist = 1;
+    // The ID of the created watchlist.
+    WatchlistId watchlist = 1;
 
-  // The name of the created watchlist.
-  string name = 2 [(required) = true];
+    // The name of the created watchlist.
+    string name = 2 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/shareaware/watchlist/events.proto
+++ b/model/src/main/proto/spine_examples/shareaware/watchlist/events.proto
@@ -26,23 +26,23 @@
 
 syntax = "proto3";
 
-package spine_examples.shareaware.command;
+package spine_examples.shareaware.watchlist.event;
 
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.shareaware.spine.io";
-option java_package = "io.spine.examples.shareaware.command";
-option java_outer_classname = "CommandsProto";
+option java_package = "io.spine.examples.shareaware.watchlist.event";
+option java_outer_classname = "EventsProto";
 option java_multiple_files = true;
 
 import "spine_examples/shareaware/identifiers.proto";
 
-// A command to create a new watchlist.
-message CreateWatchlist {
+// A new watchlist has been created.
+message WatchlistCreated {
 
-    // The ID of the watchlist to create.
-    WatchlistId watchlist = 1;
+  // The ID of the created watchlist.
+  WatchlistId watchlist = 1;
 
-    // The name of the watchlist.
-    string name = 2 [(required) = true];
+  // The name of the created watchlist.
+  string name = 2 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/shareaware/watchlist/events.proto
+++ b/model/src/main/proto/spine_examples/shareaware/watchlist/events.proto
@@ -26,7 +26,7 @@
 
 syntax = "proto3";
 
-package spine_examples.shareaware.watchlist.event;
+package spine_examples.shareaware.watchlist;
 
 import "spine/options.proto";
 


### PR DESCRIPTION
This PR moves `commands.proto` and `events.proto` to the entity package.