### PR TITLE
Implement ID for operations that participate in wallet replenishment

### DIFF
--- a/model/src/main/java/io/spine/examples/shareaware/wallet/MoneyReservationSignal.java
+++ b/model/src/main/java/io/spine/examples/shareaware/wallet/MoneyReservationSignal.java
@@ -29,7 +29,7 @@ package io.spine.examples.shareaware.wallet;
 import com.google.errorprone.annotations.Immutable;
 import io.spine.annotation.GeneratedMixin;
 import io.spine.base.EventMessage;
-import io.spine.examples.shareaware.OperationId;
+import io.spine.examples.shareaware.WithdrawalOperationId;
 import io.spine.examples.shareaware.PurchaseId;
 import io.spine.examples.shareaware.WithdrawalId;
 
@@ -43,7 +43,7 @@ public interface MoneyReservationSignal extends EventMessage {
     /**
      * Returns the ID of operation, in the scope of which this signal is emitted.
      */
-    OperationId getOperation();
+    WithdrawalOperationId getOperation();
 
     /**
      * Retrieves {@code WithdrawalId} from {@code OperationId} without checking for its existence.

--- a/model/src/main/java/io/spine/examples/shareaware/wallet/MoneyWithdrawalSignal.java
+++ b/model/src/main/java/io/spine/examples/shareaware/wallet/MoneyWithdrawalSignal.java
@@ -34,11 +34,11 @@ import io.spine.examples.shareaware.PurchaseId;
 import io.spine.examples.shareaware.WithdrawalId;
 
 /**
- * Common interface for signals participating in the money reservation operation.
+ * Common interface for signals participating in the money withdrawal operation.
  */
 @Immutable
 @GeneratedMixin
-public interface MoneyReservationSignal extends EventMessage {
+public interface MoneyWithdrawalSignal extends EventMessage {
 
     /**
      * Returns the ID of operation, in the scope of which this signal is emitted.

--- a/model/src/main/java/io/spine/examples/shareaware/wallet/MoneyWithdrawalSignal.java
+++ b/model/src/main/java/io/spine/examples/shareaware/wallet/MoneyWithdrawalSignal.java
@@ -34,7 +34,7 @@ import io.spine.examples.shareaware.PurchaseId;
 import io.spine.examples.shareaware.WithdrawalId;
 
 /**
- * Common interface for signals participating in the money withdrawal operation.
+ * Common interface for signals participating in the money withdrawal operations.
  */
 @Immutable
 @GeneratedMixin

--- a/model/src/main/proto/spine_examples/shareaware/identifiers.proto
+++ b/model/src/main/proto/spine_examples/shareaware/identifiers.proto
@@ -82,8 +82,15 @@ message PurchaseId {
 
 // Identifies the operation that reserve and withdraw money from the wallet.
 message WithdrawalOperationId {
+
     oneof type {
+
+        // The ID of the `WalletWithdrawal` process
+        // that withdraws money from the wallet to the user's bank account.
         WithdrawalId withdrawal = 1;
+
+        // The ID of the `SharesPurchase` process
+        // that withdraws money from the user's wallet for shares purchase.
         PurchaseId purchase = 2;
     }
 }
@@ -100,8 +107,15 @@ message SaleId {
 
 // Identifies the operation that replenishes the wallet.
 message ReplenishmentOperationId {
+
     oneof type {
+
+        // The ID of the `WalletReplenishment` process
+        // that replenishes the wallet from the user's bank account.
         ReplenishmentId replenishment = 1;
+
+        // The ID of the `SharesSale` process
+        // that replenishes the wallet by selling the user's shares on the market.
         SaleId sale = 2;
     }
 }

--- a/model/src/main/proto/spine_examples/shareaware/identifiers.proto
+++ b/model/src/main/proto/spine_examples/shareaware/identifiers.proto
@@ -81,7 +81,7 @@ message PurchaseId {
 }
 
 // Identifies the operation that interacts with the wallet by reserving money in it.
-message OperationId {
+message WithdrawalOperationId {
     oneof type {
         WithdrawalId withdrawal = 1;
         PurchaseId purchase = 2;

--- a/model/src/main/proto/spine_examples/shareaware/identifiers.proto
+++ b/model/src/main/proto/spine_examples/shareaware/identifiers.proto
@@ -97,3 +97,11 @@ message MarketId {
 message SaleId {
     string uuid = 1 [(required) = true];
 }
+
+// Identifies the operation that replenishes the wallet.
+message ReplenishmentOperationId {
+    oneof type {
+        ReplenishmentId replenishment = 1;
+        SaleId sale = 2;
+    }
+}

--- a/model/src/main/proto/spine_examples/shareaware/identifiers.proto
+++ b/model/src/main/proto/spine_examples/shareaware/identifiers.proto
@@ -80,7 +80,7 @@ message PurchaseId {
     string uuid = 1 [(required) = true];
 }
 
-// Identifies the operation that interacts with the wallet by reserving money in it.
+// Identifies the operation that reserve and withdraw money from the wallet.
 message WithdrawalOperationId {
     oneof type {
         WithdrawalId withdrawal = 1;

--- a/model/src/main/proto/spine_examples/shareaware/wallet/commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/wallet/commands.proto
@@ -65,7 +65,7 @@ message ReserveMoney {
     WalletId wallet = 1;
 
     // The ID of the pending operation that wants to reserve money.
-    OperationId operation = 2 [(required) = true];
+    WithdrawalOperationId operation = 2 [(required) = true];
 
     // Wanted amount of money to be reserved.
     spine.money.Money amount = 3 [(required) = true];
@@ -83,7 +83,7 @@ message DebitReservedMoney {
     WalletId wallet = 1;
 
     // The ID of the operation that wants to debit the reserved money.
-    OperationId operation = 2 [(required) = true];
+    WithdrawalOperationId operation = 2 [(required) = true];
 }
 
 // A command to cancel money reservation.
@@ -97,5 +97,5 @@ message CancelMoneyReservation {
     WalletId wallet = 1;
 
     // The ID of the operation that wants to cancel the money reservation.
-    OperationId operation = 2 [(required) = true];
+    WithdrawalOperationId operation = 2 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/shareaware/wallet/commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/wallet/commands.proto
@@ -51,8 +51,8 @@ message RechargeBalance {
     // The ID of the wallet whose balance must be recharged.
     WalletId wallet = 1;
 
-    // The ID of the replenishment process invokes the balance recharging.
-    ReplenishmentId replenishment_process = 2 [(required) = true];
+    // The ID of the operation invokes the balance recharging.
+    ReplenishmentOperationId operation = 2 [(required) = true];
 
     // The amount of money by which the wallet balance must be recharged.
     spine.money.Money money_amount = 3 [(required) = true];

--- a/model/src/main/proto/spine_examples/shareaware/wallet/commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/wallet/commands.proto
@@ -51,7 +51,7 @@ message RechargeBalance {
     // The ID of the wallet whose balance must be recharged.
     WalletId wallet = 1;
 
-    // The ID of the operation invokes the balance recharging.
+    // The ID of the operation that invokes the balance recharging.
     ReplenishmentOperationId operation = 2 [(required) = true];
 
     // The amount of money by which the wallet balance must be recharged.

--- a/model/src/main/proto/spine_examples/shareaware/wallet/events.proto
+++ b/model/src/main/proto/spine_examples/shareaware/wallet/events.proto
@@ -63,7 +63,7 @@ message BalanceRecharged {
 
 // Money has been reserved in the wallet.
 message MoneyReserved {
-    option (is).java_type = "io.spine.examples.shareaware.wallet.MoneyReservationSignal";
+    option (is).java_type = "io.spine.examples.shareaware.wallet.MoneyWithdrawalSignal";
 
     // The ID of the wallet where money has been reserved.
     WalletId wallet = 1;
@@ -77,7 +77,7 @@ message MoneyReserved {
 
 // The reserved money has been debited.
 message ReservedMoneyDebited {
-    option (is).java_type = "io.spine.examples.shareaware.wallet.MoneyReservationSignal";
+    option (is).java_type = "io.spine.examples.shareaware.wallet.MoneyWithdrawalSignal";
 
     // The ID of the wallet where reserved money has been debited.
     WalletId wallet = 1;
@@ -91,7 +91,7 @@ message ReservedMoneyDebited {
 
 // The money reservation has been canceled.
 message MoneyReservationCanceled {
-    option (is).java_type = "io.spine.examples.shareaware.wallet.MoneyReservationSignal";
+    option (is).java_type = "io.spine.examples.shareaware.wallet.MoneyWithdrawalSignal";
 
     // The ID of the wallet where money reservation was canceled.
     WalletId wallet = 1;

--- a/model/src/main/proto/spine_examples/shareaware/wallet/events.proto
+++ b/model/src/main/proto/spine_examples/shareaware/wallet/events.proto
@@ -69,7 +69,7 @@ message MoneyReserved {
     WalletId wallet = 1;
 
     // The ID of the operation that reserved money.
-    OperationId operation = 2 [(required) = true];
+    WithdrawalOperationId operation = 2 [(required) = true];
 
     // The amount of money that has been reserved.
     spine.money.Money amount = 3 [(required) = true];
@@ -83,7 +83,7 @@ message ReservedMoneyDebited {
     WalletId wallet = 1;
 
     // The ID of the operation that debited the reserved money.
-    OperationId operation = 2 [(required) = true];
+    WithdrawalOperationId operation = 2 [(required) = true];
 
     // The current wallet balance after the reserved money was debited.
     spine.money.Money current_balance = 3 [(required) = true];
@@ -97,5 +97,5 @@ message MoneyReservationCanceled {
     WalletId wallet = 1;
 
     // The ID of the operation that canceled money reservation.
-    OperationId operation = 2 [(required) = true];
+    WithdrawalOperationId operation = 2 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/shareaware/wallet/events.proto
+++ b/model/src/main/proto/spine_examples/shareaware/wallet/events.proto
@@ -54,8 +54,8 @@ message BalanceRecharged {
     // The ID of the wallet whose balance was recharged.
     WalletId wallet = 1;
 
-    // The ID of the replenishment process that has invoked balance recharging.
-    ReplenishmentId replenishment_process = 2 [(required) = true];
+    // The ID of the operation that has invoked balance recharging.
+    ReplenishmentOperationId operation = 2 [(required) = true];
 
     // The amount of money by which the wallet balance was recharged.
     spine.money.Money money_amount = 3 [(required) = true];

--- a/model/src/main/proto/spine_examples/shareaware/wallet/rejections.proto
+++ b/model/src/main/proto/spine_examples/shareaware/wallet/rejections.proto
@@ -39,7 +39,7 @@ import "spine/money/money.proto";
 
 // Money cannot be reserved due to insufficient funds in the wallet.
 message InsufficientFunds {
-    option (is).java_type = "io.spine.examples.shareaware.wallet.MoneyReservationSignal";
+    option (is).java_type = "io.spine.examples.shareaware.wallet.MoneyWithdrawalSignal";
 
     // The ID of the wallet has no such amount of money to reserve.
     WalletId wallet = 1;

--- a/model/src/main/proto/spine_examples/shareaware/wallet/rejections.proto
+++ b/model/src/main/proto/spine_examples/shareaware/wallet/rejections.proto
@@ -45,7 +45,7 @@ message InsufficientFunds {
     WalletId wallet = 1;
 
     // The ID of the operation that wanted to reserve money.
-    OperationId operation = 2 [(required) = true];
+    WithdrawalOperationId operation = 2 [(required) = true];
 
     // The amount of not reserved money.
     spine.money.Money amount = 3 [(required) = true];

--- a/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesPurchaseProcess.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesPurchaseProcess.java
@@ -28,7 +28,7 @@ package io.spine.examples.shareaware.server.investment;
 
 import io.spine.core.UserId;
 import io.spine.examples.shareaware.InvestmentId;
-import io.spine.examples.shareaware.OperationId;
+import io.spine.examples.shareaware.WithdrawalOperationId;
 import io.spine.examples.shareaware.PurchaseId;
 import io.spine.examples.shareaware.WalletId;
 import io.spine.examples.shareaware.investment.SharesPurchase;
@@ -203,15 +203,15 @@ final class SharesPurchaseProcess
                 .vBuild();
     }
 
-    private OperationId operationId() {
-        return OperationId
+    private WithdrawalOperationId operationId() {
+        return WithdrawalOperationId
                 .newBuilder()
                 .setPurchase(state().getId())
                 .vBuild();
     }
 
-    private static OperationId operationId(PurchaseId id) {
-        return OperationId
+    private static WithdrawalOperationId operationId(PurchaseId id) {
+        return WithdrawalOperationId
                 .newBuilder()
                 .setPurchase(id)
                 .vBuild();

--- a/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesPurchaseRepository.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesPurchaseRepository.java
@@ -33,7 +33,7 @@ import io.spine.examples.shareaware.investment.SharesPurchase;
 import io.spine.examples.shareaware.investment.event.SharesAdded;
 import io.spine.examples.shareaware.market.event.SharesObtained;
 import io.spine.examples.shareaware.market.rejection.Rejections.SharesCannotBeObtained;
-import io.spine.examples.shareaware.wallet.MoneyReservationSignal;
+import io.spine.examples.shareaware.wallet.MoneyWithdrawalSignal;
 import io.spine.examples.shareaware.wallet.event.MoneyReservationCanceled;
 import io.spine.examples.shareaware.wallet.event.MoneyReserved;
 import io.spine.examples.shareaware.wallet.event.ReservedMoneyDebited;
@@ -71,7 +71,7 @@ public final class SharesPurchaseRepository
                       (event, context) -> withPurchaseId(event));
     }
 
-    private static Set<PurchaseId> withPurchaseId(MoneyReservationSignal e) {
+    private static Set<PurchaseId> withPurchaseId(MoneyWithdrawalSignal e) {
         if (e.isPartOfPurchase()) {
             return ImmutableSet.of(e.purchaseProcess());
         }

--- a/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletAggregate.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletAggregate.java
@@ -87,7 +87,7 @@ public final class WalletAggregate extends Aggregate<WalletId, Wallet, Wallet.Bu
                 .newBuilder()
                 .setWallet(c.getWallet())
                 .setMoneyAmount(c.getMoneyAmount())
-                .setReplenishmentProcess(c.getReplenishmentProcess())
+                .setOperation(c.getOperation())
                 .vBuild();
     }
 

--- a/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletReplenishmentProcess.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletReplenishmentProcess.java
@@ -27,6 +27,7 @@
 package io.spine.examples.shareaware.server.wallet;
 
 import io.spine.examples.shareaware.ReplenishmentId;
+import io.spine.examples.shareaware.ReplenishmentOperationId;
 import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyFromUser;
 import io.spine.examples.shareaware.paymentgateway.event.MoneyTransferredFromUser;
 import io.spine.examples.shareaware.paymentgateway.rejection.Rejections.MoneyCannotBeTransferredFromUser;
@@ -84,7 +85,7 @@ final class WalletReplenishmentProcess
         return RechargeBalance
                 .newBuilder()
                 .setWallet(state().getWallet())
-                .setReplenishmentProcess(state().getId())
+                .setOperation(operationId())
                 .setMoneyAmount(e.getAmount())
                 .vBuild();
     }
@@ -113,6 +114,13 @@ final class WalletReplenishmentProcess
                 .newBuilder()
                 .setReplenishment(r.getReplenishment())
                 .setCause(r.getCause())
+                .vBuild();
+    }
+
+    private ReplenishmentOperationId operationId() {
+        return ReplenishmentOperationId
+                .newBuilder()
+                .setReplenishment(state().getId())
                 .vBuild();
     }
 }

--- a/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletReplenishmentRepository.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletReplenishmentRepository.java
@@ -26,14 +26,17 @@
 
 package io.spine.examples.shareaware.server.wallet;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import io.spine.examples.shareaware.ReplenishmentId;
+import io.spine.examples.shareaware.ReplenishmentOperationId;
 import io.spine.examples.shareaware.paymentgateway.event.MoneyTransferredFromUser;
 import io.spine.examples.shareaware.wallet.WalletReplenishment;
 import io.spine.examples.shareaware.wallet.event.BalanceRecharged;
 import io.spine.server.procman.ProcessManagerRepository;
-import io.spine.server.route.EventRoute;
 import io.spine.server.route.EventRouting;
+
+import java.util.Set;
 
 import static io.spine.server.route.EventRoute.*;
 
@@ -49,7 +52,14 @@ public final class WalletReplenishmentRepository
         super.setupEventRouting(routing);
         routing.route(MoneyTransferredFromUser.class,
                       (event, context) -> withId(event.getReplenishmentProcess()));
-        routing.route(BalanceRecharged.class, (
-                event, context) -> withId(event.getReplenishmentProcess()));
+        routing.route(BalanceRecharged.class,
+                      (event, context) -> withReplenishmentId(event.getOperation()));
+    }
+
+    private static Set<ReplenishmentId> withReplenishmentId(ReplenishmentOperationId id) {
+        if (id.hasReplenishment()) {
+            return ImmutableSet.of(id.getReplenishment());
+        }
+        return ImmutableSet.of();
     }
 }

--- a/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletWithdrawalProcess.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletWithdrawalProcess.java
@@ -26,7 +26,7 @@
 
 package io.spine.examples.shareaware.server.wallet;
 
-import io.spine.examples.shareaware.OperationId;
+import io.spine.examples.shareaware.WithdrawalOperationId;
 import io.spine.examples.shareaware.WithdrawalId;
 import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyToUser;
 import io.spine.examples.shareaware.paymentgateway.event.MoneyTransferredToUser;
@@ -154,8 +154,8 @@ final class WalletWithdrawalProcess
                 .vBuild();
     }
 
-    private static OperationId operationId(WithdrawalId withdrawal) {
-        return OperationId
+    private static WithdrawalOperationId operationId(WithdrawalId withdrawal) {
+        return WithdrawalOperationId
                 .newBuilder()
                 .setWithdrawal(withdrawal)
                 .vBuild();

--- a/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletWithdrawalRepository.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletWithdrawalRepository.java
@@ -31,7 +31,7 @@ import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import io.spine.examples.shareaware.WithdrawalId;
 import io.spine.examples.shareaware.paymentgateway.event.MoneyTransferredToUser;
 import io.spine.examples.shareaware.paymentgateway.rejection.Rejections.MoneyCannotBeTransferredToUser;
-import io.spine.examples.shareaware.wallet.MoneyReservationSignal;
+import io.spine.examples.shareaware.wallet.MoneyWithdrawalSignal;
 import io.spine.examples.shareaware.wallet.WalletWithdrawal;
 import io.spine.examples.shareaware.wallet.event.MoneyReservationCanceled;
 import io.spine.examples.shareaware.wallet.event.MoneyReserved;
@@ -68,7 +68,7 @@ public final class WalletWithdrawalRepository
                       (event, context) -> withId(event.getWithdrawalProcess()));
     }
 
-    private static Set<WithdrawalId> withWithdrawalId(MoneyReservationSignal e) {
+    private static Set<WithdrawalId> withWithdrawalId(MoneyWithdrawalSignal e) {
         if (e.isPartOfWithdrawal()) {
             return ImmutableSet.of(e.withdrawalProcess());
         }

--- a/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
@@ -2,6 +2,7 @@ package io.spine.examples.shareaware.server.given;
 
 import io.spine.examples.shareaware.OperationId;
 import io.spine.examples.shareaware.ReplenishmentId;
+import io.spine.examples.shareaware.ReplenishmentOperationId;
 import io.spine.examples.shareaware.WalletId;
 import io.spine.examples.shareaware.WithdrawalId;
 import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyFromUser;
@@ -120,7 +121,7 @@ public final class WalletTestEnv {
                 .newBuilder()
                 .setWallet(wallet)
                 .setMoneyAmount(command.getMoneyAmount())
-                .setReplenishmentProcess(command.getReplenishment())
+                .setOperation(operationId(command))
                 .vBuild();
     }
 
@@ -161,7 +162,7 @@ public final class WalletTestEnv {
         return RechargeBalance
                 .newBuilder()
                 .setWallet(command.getWallet())
-                .setReplenishmentProcess(command.getReplenishment())
+                .setOperation(operationId(command))
                 .setMoneyAmount(command.getMoneyAmount())
                 .vBuild();
     }
@@ -377,6 +378,13 @@ public final class WalletTestEnv {
                 .newBuilder()
                 .setId(id)
                 .setBalance(GivenMoney.zero())
+                .vBuild();
+    }
+
+    private static ReplenishmentOperationId operationId(ReplenishWallet c) {
+        return ReplenishmentOperationId
+                .newBuilder()
+                .setReplenishment(c.getReplenishment())
                 .vBuild();
     }
 }

--- a/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
@@ -1,6 +1,6 @@
 package io.spine.examples.shareaware.server.given;
 
-import io.spine.examples.shareaware.OperationId;
+import io.spine.examples.shareaware.WithdrawalOperationId;
 import io.spine.examples.shareaware.ReplenishmentId;
 import io.spine.examples.shareaware.ReplenishmentOperationId;
 import io.spine.examples.shareaware.WalletId;
@@ -213,8 +213,8 @@ public final class WalletTestEnv {
                 .vBuild();
     }
 
-    private static OperationId operationId(WithdrawalId withdrawal) {
-        return OperationId
+    private static WithdrawalOperationId operationId(WithdrawalId withdrawal) {
+        return WithdrawalOperationId
                 .newBuilder()
                 .setWithdrawal(withdrawal)
                 .vBuild();

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
@@ -28,7 +28,7 @@ package io.spine.examples.shareaware.server.investment.given;
 
 import io.spine.core.UserId;
 import io.spine.examples.shareaware.InvestmentId;
-import io.spine.examples.shareaware.OperationId;
+import io.spine.examples.shareaware.WithdrawalOperationId;
 import io.spine.examples.shareaware.PurchaseId;
 import io.spine.examples.shareaware.ShareId;
 import io.spine.examples.shareaware.WalletId;
@@ -236,8 +236,8 @@ public final class InvestmentTestEnv {
                 .vBuild();
     }
 
-    private static OperationId operationId(PurchaseId id) {
-        return OperationId
+    private static WithdrawalOperationId operationId(PurchaseId id) {
+        return WithdrawalOperationId
                 .newBuilder()
                 .setPurchase(id)
                 .vBuild();


### PR DESCRIPTION
This PR implements `ReplenishmentOperationID`, which represents the "one of" IDs containing `SaleId` or `ReplenishmentId`. These changes were provoked by the fact that the `SharesSale` process and the `WalletReplenishment` process replenish the wallet, but in previous PRs it was not clear to me and I have bonded the balance recharging action to the `ReplenishmentId`. I have fixed it and now both the `WalletReplenishment` and the `SharesSale` process can recharge the wallet balance.