### PR TITLE
Adjust the list of subscriptions for the `WalletBalance` projection

### DIFF
--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -43,13 +43,13 @@ configurations {
     create("test")
 }
 
-tasks.register<Jar>("testArchive") {
+var testOutputTask = tasks.register<Jar>("testOutput") {
     archiveBaseName.set("module-test")
     from(project.the<SourceSetContainer>()["test"].output)
 }
 
 artifacts {
-    add("test", tasks["testArchive"])
+    add("test", testOutputTask)
 }
 
 dependencies {

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -39,6 +39,19 @@ spine {
     enableJava()
 }
 
+configurations {
+    create("test")
+}
+
+tasks.register<Jar>("testArchive") {
+    archiveBaseName.set("module-test")
+    from(project.the<SourceSetContainer>()["test"].output)
+}
+
+artifacts {
+    add("test", tasks["testArchive"])
+}
+
 dependencies {
     implementation(Spine.Server.lib)
 }

--- a/model/src/main/java/io/spine/examples/shareaware/MoneyCalculator.java
+++ b/model/src/main/java/io/spine/examples/shareaware/MoneyCalculator.java
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.shareaware.server.wallet;
+package io.spine.examples.shareaware;
 
 import com.google.common.base.Preconditions;
 import io.spine.money.Money;
@@ -110,7 +110,7 @@ public final class MoneyCalculator {
      * Returns true if the first {@code Money} object is greater
      * than the second {@code Money} object, or false otherwise.
      */
-    static boolean isGreater(Money first, Money second) {
+    public static boolean isGreater(Money first, Money second) {
         checkArguments(first, second);
         if (first.getUnits() > second.getUnits()) {
             return true;

--- a/model/src/main/java/io/spine/examples/shareaware/investment/OperationPriceMixin.java
+++ b/model/src/main/java/io/spine/examples/shareaware/investment/OperationPriceMixin.java
@@ -33,6 +33,10 @@ import io.spine.money.Money;
 
 import static io.spine.examples.shareaware.MoneyCalculator.*;
 
+/**
+ * Defined custom methods for signals that participate
+ * in the monetary operations related to shares.
+ */
 @Immutable
 @GeneratedMixin
 public interface OperationPriceMixin extends SerializableMessage {
@@ -41,6 +45,9 @@ public interface OperationPriceMixin extends SerializableMessage {
 
     Money getSharePrice();
 
+    /**
+     * Returns the total price of the transaction that operates with shares.
+     */
     default Money operationPrice() {
         return multiply(getSharePrice(), getQuantity());
     }

--- a/model/src/main/java/io/spine/examples/shareaware/investment/OperationPriceMixin.java
+++ b/model/src/main/java/io/spine/examples/shareaware/investment/OperationPriceMixin.java
@@ -24,37 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-syntax = "proto3";
+package io.spine.examples.shareaware.investment;
 
-package spine_examples.shareaware.investment;
+import com.google.errorprone.annotations.Immutable;
+import io.spine.annotation.GeneratedMixin;
+import io.spine.base.SerializableMessage;
+import io.spine.money.Money;
 
-import "spine/options.proto";
+import static io.spine.examples.shareaware.MoneyCalculator.*;
 
-option (type_url_prefix) = "type.shareaware.spine.io";
-option java_package = "io.spine.examples.shareaware.investment.command";
-option java_outer_classname = "PurchaseCommandsProto";
-option java_multiple_files = true;
+@Immutable
+@GeneratedMixin
+public interface OperationPriceMixin extends SerializableMessage {
 
-import "spine_examples/shareaware/identifiers.proto";
-import "spine/money/money.proto";
-import "spine/core/user_id.proto";
+    int getQuantity();
 
-// An intent of the user to purchase shares.
-message PurchaseShares {
-    option (is).java_type = "io.spine.examples.shareaware.investment.OperationPriceMixin";
+    Money getSharePrice();
 
-    // The ID of the purchase process.
-    PurchaseId purchase_process = 1;
-
-    // The ID of the user who wants to purchase shares.
-    spine.core.UserId purchaser = 2 [(required) = true];
-
-    // The ID of the share to purchase.
-    ShareId share = 3 [(required) = true];
-
-    // The quantity of shares to purchase.
-    int32 quantity = 4 [(required) = true];
-
-    // The price per share at the time of purchase.
-    spine.money.Money share_price = 5 [(required) = true];
+    default Money operationPrice() {
+        return multiply(getSharePrice(), getQuantity());
+    }
 }

--- a/model/src/main/java/io/spine/examples/shareaware/investment/WithSellingShares.java
+++ b/model/src/main/java/io/spine/examples/shareaware/investment/WithSellingShares.java
@@ -34,12 +34,11 @@ import io.spine.money.Money;
 import static io.spine.examples.shareaware.MoneyCalculator.*;
 
 /**
- * Defined custom methods for signals that participate
- * in the monetary operations related to shares.
+ * Provides a convenience API for signals describing the operations on shares sale.
  */
 @Immutable
 @GeneratedMixin
-public interface OperationPriceMixin extends SerializableMessage {
+public interface WithSellingShares extends SerializableMessage {
 
     int getQuantity();
 
@@ -48,7 +47,7 @@ public interface OperationPriceMixin extends SerializableMessage {
     /**
      * Returns the total price of the transaction that operates with shares.
      */
-    default Money operationPrice() {
+    default Money totalCost() {
         return multiply(getSharePrice(), getQuantity());
     }
 }

--- a/model/src/main/java/io/spine/examples/shareaware/investment/WithSellingShares.java
+++ b/model/src/main/java/io/spine/examples/shareaware/investment/WithSellingShares.java
@@ -40,12 +40,18 @@ import static io.spine.examples.shareaware.MoneyCalculator.*;
 @GeneratedMixin
 public interface WithSellingShares extends SerializableMessage {
 
+    /**
+     * Returns the quantity of shares described by this signal.
+     */
     int getQuantity();
 
+    /**
+     * Returns the price per share.
+     */
     Money getPrice();
 
     /**
-     * Returns the total price of the transaction that operates with shares.
+     * Returns the price of shares described by this signal.
      */
     default Money totalCost() {
         return multiply(getPrice(), getQuantity());

--- a/model/src/main/java/io/spine/examples/shareaware/investment/WithSellingShares.java
+++ b/model/src/main/java/io/spine/examples/shareaware/investment/WithSellingShares.java
@@ -42,12 +42,12 @@ public interface WithSellingShares extends SerializableMessage {
 
     int getQuantity();
 
-    Money getSharePrice();
+    Money getPrice();
 
     /**
      * Returns the total price of the transaction that operates with shares.
      */
     default Money totalCost() {
-        return multiply(getSharePrice(), getQuantity());
+        return multiply(getPrice(), getQuantity());
     }
 }

--- a/model/src/main/proto/spine_examples/shareaware/investment/purchase_commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/purchase_commands.proto
@@ -41,7 +41,7 @@ import "spine/core/user_id.proto";
 
 // An intent of the user to purchase shares.
 message PurchaseShares {
-    option (is).java_type = "io.spine.examples.shareaware.investment.OperationPriceMixin";
+    option (is).java_type = "io.spine.examples.shareaware.investment.WithSellingShares";
 
     // The ID of the purchase process.
     PurchaseId purchase_process = 1;

--- a/model/src/main/proto/spine_examples/shareaware/investment/purchase_commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/purchase_commands.proto
@@ -56,5 +56,5 @@ message PurchaseShares {
     int32 quantity = 4 [(required) = true];
 
     // The price per share at the time of purchase.
-    spine.money.Money share_price = 5 [(required) = true];
+    spine.money.Money price = 5 [(required) = true];
 }

--- a/model/src/main/proto/spine_examples/shareaware/investment/sale_commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/sale_commands.proto
@@ -41,7 +41,7 @@ import "spine/core/user_id.proto";
 
 // An intent of the user to sell shares.
 message SellShares {
-    option (is).java_type = "io.spine.examples.shareaware.investment.OperationPriceMixin";
+    option (is).java_type = "io.spine.examples.shareaware.investment.WithSellingShares";
 
     // The ID of the shares sale process.
     SaleId sale_process = 1;

--- a/model/src/main/proto/spine_examples/shareaware/investment/sale_commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/sale_commands.proto
@@ -41,6 +41,7 @@ import "spine/core/user_id.proto";
 
 // An intent of the user to sell shares.
 message SellShares {
+    option (is).java_type = "io.spine.examples.shareaware.investment.OperationPriceMixin";
 
     // The ID of the shares sale process.
     SaleId sale_process = 1;
@@ -59,7 +60,7 @@ message SellShares {
     // In case when the actual price on the market differs from the wanted price,
     // the market will reject the sale.
     //
-    spine.money.Money price = 4 [(required) = true];
+    spine.money.Money share_price = 4 [(required) = true];
 
     // The quantity of shares to sell.
     int32 quantity = 5 [(required) = true];

--- a/model/src/main/proto/spine_examples/shareaware/investment/sale_commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/sale_commands.proto
@@ -60,7 +60,7 @@ message SellShares {
     // In case when the actual price on the market differs from the wanted price,
     // the market will reject the sale.
     //
-    spine.money.Money share_price = 4 [(required) = true];
+    spine.money.Money price = 4 [(required) = true];
 
     // The quantity of shares to sell.
     int32 quantity = 5 [(required) = true];

--- a/model/src/main/proto/spine_examples/shareaware/wallet/events.proto
+++ b/model/src/main/proto/spine_examples/shareaware/wallet/events.proto
@@ -57,8 +57,8 @@ message BalanceRecharged {
     // The ID of the operation that has invoked balance recharging.
     ReplenishmentOperationId operation = 2 [(required) = true];
 
-    // The amount of money by which the wallet balance was recharged.
-    spine.money.Money money_amount = 3 [(required) = true];
+    // The current wallet balance after recharging.
+    spine.money.Money current_balance = 3 [(required) = true];
 }
 
 // Money has been reserved in the wallet.

--- a/model/src/main/proto/spine_examples/shareaware/wallet/wallet.proto
+++ b/model/src/main/proto/spine_examples/shareaware/wallet/wallet.proto
@@ -76,6 +76,9 @@ message WalletReplenishment {
 
     // The ID of the wallet to replenish.
     WalletId wallet = 2;
+
+    // The amount of money by which the wallet is replenished.
+    spine.money.Money money_amount = 3;
 }
 
 // The process of wallet withdrawal.

--- a/model/src/main/proto/spine_examples/shareaware/wallet/wallet.proto
+++ b/model/src/main/proto/spine_examples/shareaware/wallet/wallet.proto
@@ -78,7 +78,7 @@ message WalletReplenishment {
     WalletId wallet = 2;
 
     // The amount of money by which the wallet is replenished.
-    spine.money.Money money_amount = 3;
+    spine.money.Money amount = 3;
 }
 
 // The process of wallet withdrawal.

--- a/model/src/main/proto/spine_examples/shareaware/wallet/wallet.proto
+++ b/model/src/main/proto/spine_examples/shareaware/wallet/wallet.proto
@@ -75,10 +75,10 @@ message WalletReplenishment {
     ReplenishmentId id = 1;
 
     // The ID of the wallet to replenish.
-    WalletId wallet = 2;
+    WalletId wallet = 2 [(required) = true];
 
     // The amount of money by which the wallet is replenished.
-    spine.money.Money amount = 3;
+    spine.money.Money amount = 3 [(required) = true];
 }
 
 // The process of wallet withdrawal.

--- a/model/src/test/java/io/spine/examples/shareaware/MoneyCalculatorAbstractTest.java
+++ b/model/src/test/java/io/spine/examples/shareaware/MoneyCalculatorAbstractTest.java
@@ -36,8 +36,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.function.BiFunction;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.spine.examples.shareaware.server.given.GivenMoney.moneyOf;
-import static io.spine.examples.shareaware.server.given.GivenMoney.usd;
+import static io.spine.examples.shareaware.given.GivenMoney.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/model/src/test/java/io/spine/examples/shareaware/MoneyCalculatorTest.java
+++ b/model/src/test/java/io/spine/examples/shareaware/MoneyCalculatorTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.stream.Stream;
 
-import static io.spine.examples.shareaware.server.given.GivenMoney.*;
+import static io.spine.examples.shareaware.given.GivenMoney.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.*;
 

--- a/model/src/test/java/io/spine/examples/shareaware/given/GivenMoney.java
+++ b/model/src/test/java/io/spine/examples/shareaware/given/GivenMoney.java
@@ -41,7 +41,7 @@ public final class GivenMoney {
     }
 
     /**
-     * Returns the {@code Money} instance with zero value in USD currency.
+     * Returns the {@code Money} instance with zero value in the USD currency.
      */
     public static Money zero() {
         return Money
@@ -55,6 +55,8 @@ public final class GivenMoney {
     /**
      * Creates the instance of {@code Money} with provided values of
      * {@link Money#units_} and {@link Money#currency_}.
+     *
+     * <p>The {@link Money#nanos_} value is set to zero by default.
      */
     public static Money moneyOf(long units, Currency currency) {
         return Money
@@ -89,6 +91,8 @@ public final class GivenMoney {
     /**
      * Creates the {@code Money} instance in USD currency
      * with a provided value of {@link Money#units_}.
+     *
+     * <p>The {@link Money#nanos_} value is set to zero by default.
      */
     public static Money usd(long units) {
         return moneyOf(units, Currency.USD);

--- a/model/src/test/java/io/spine/examples/shareaware/given/GivenMoney.java
+++ b/model/src/test/java/io/spine/examples/shareaware/given/GivenMoney.java
@@ -54,9 +54,9 @@ public final class GivenMoney {
 
     /**
      * Creates the instance of {@code Money} with provided values of
-     * {@link Money#units_} and {@link Money#currency_}.
+     * units and currency.
      *
-     * <p>The {@link Money#nanos_} value is set to zero by default.
+     * <p>The nanos value is always set to zero.
      */
     public static Money moneyOf(long units, Currency currency) {
         return Money
@@ -68,8 +68,8 @@ public final class GivenMoney {
     }
 
     /**
-     * Creates the instance of {@code Money} with provided values of {@link Money#units_},
-     * {@link Money#nanos_}, and {@link Money#currency_}.
+     * Creates the instance of {@code Money} with provided values of units,
+     * nanos, and currency.
      */
     public static Money moneyOf(long units, int nanos, Currency currency) {
         return Money
@@ -82,7 +82,7 @@ public final class GivenMoney {
 
     /**
      * Creates the {@code Money} instance in USD currency with provided values of
-     * {@link Money#units_} and {@link Money#nanos_}.
+     * units and nanos.
      */
     public static Money usd(long units, int nanos) {
         return moneyOf(units, nanos, Currency.USD);
@@ -90,9 +90,9 @@ public final class GivenMoney {
 
     /**
      * Creates the {@code Money} instance in USD currency
-     * with a provided value of {@link Money#units_}.
+     * with a provided value of units.
      *
-     * <p>The {@link Money#nanos_} value is set to zero by default.
+     * <p>The nanos value is always set to zero.
      */
     public static Money usd(long units) {
         return moneyOf(units, Currency.USD);

--- a/model/src/test/java/io/spine/examples/shareaware/given/GivenMoney.java
+++ b/model/src/test/java/io/spine/examples/shareaware/given/GivenMoney.java
@@ -24,24 +24,51 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*
- * Add the Gradle plugin for bootstrapping projects built with Spine.
- * See: https://github.com/SpineEventEngine/bootstrap
- */
-plugins {
-    id("io.spine.tools.gradle.bootstrap")
-}
+package io.spine.examples.shareaware.given;
 
-spine {
-    /*
-     * Add and configure required dependencies for developing a Spine-based Java server.
-     * See: https://github.com/SpineEventEngine/bootstrap#java-projects
+import io.spine.money.Currency;
+import io.spine.money.Money;
+
+public final class GivenMoney {
+
+    /**
+     * Prevents instantiation of this utility class.
      */
-    enableJava().server()
-    forceDependencies = true
-}
+    private GivenMoney() {
+    }
 
-dependencies {
-    implementation(project(":model"))
-    testImplementation(project(":model", "test"))
+    public static Money zero() {
+        return Money
+                .newBuilder()
+                .setCurrency(Currency.USD)
+                .setUnits(0)
+                .setNanos(0)
+                .vBuild();
+    }
+
+    public static Money moneyOf(long units, Currency currency) {
+        return Money
+                .newBuilder()
+                .setCurrency(currency)
+                .setUnits(units)
+                .setNanos(0)
+                .vBuild();
+    }
+
+    public static Money moneyOf(long units, int nanos, Currency currency) {
+        return Money
+                .newBuilder()
+                .setCurrency(currency)
+                .setUnits(units)
+                .setNanos(nanos)
+                .vBuild();
+    }
+
+    public static Money usd(long units, int nanos) {
+        return moneyOf(units, nanos, Currency.USD);
+    }
+
+    public static Money usd(long units) {
+        return moneyOf(units, Currency.USD);
+    }
 }

--- a/model/src/test/java/io/spine/examples/shareaware/given/GivenMoney.java
+++ b/model/src/test/java/io/spine/examples/shareaware/given/GivenMoney.java
@@ -30,7 +30,7 @@ import io.spine.money.Currency;
 import io.spine.money.Money;
 
 /**
- * Factory methods for creating {@code Money} instances for usage in tests.
+ * Factory methods for creating {@code Money} instances for test purposes.
  */
 public final class GivenMoney {
 

--- a/model/src/test/java/io/spine/examples/shareaware/given/GivenMoney.java
+++ b/model/src/test/java/io/spine/examples/shareaware/given/GivenMoney.java
@@ -29,6 +29,9 @@ package io.spine.examples.shareaware.given;
 import io.spine.money.Currency;
 import io.spine.money.Money;
 
+/**
+ * Factory methods for creating {@code Money} instances for usage in tests.
+ */
 public final class GivenMoney {
 
     /**
@@ -37,6 +40,9 @@ public final class GivenMoney {
     private GivenMoney() {
     }
 
+    /**
+     * Returns the {@code Money} instance with zero value in USD currency.
+     */
     public static Money zero() {
         return Money
                 .newBuilder()
@@ -46,6 +52,10 @@ public final class GivenMoney {
                 .vBuild();
     }
 
+    /**
+     * Creates the instance of {@code Money} with provided values of
+     * {@link Money#units_} and {@link Money#currency_}.
+     */
     public static Money moneyOf(long units, Currency currency) {
         return Money
                 .newBuilder()
@@ -55,6 +65,10 @@ public final class GivenMoney {
                 .vBuild();
     }
 
+    /**
+     * Creates the instance of {@code Money} with provided values of {@link Money#units_},
+     * {@link Money#nanos_}, and {@link Money#currency_}.
+     */
     public static Money moneyOf(long units, int nanos, Currency currency) {
         return Money
                 .newBuilder()
@@ -64,10 +78,18 @@ public final class GivenMoney {
                 .vBuild();
     }
 
+    /**
+     * Creates the {@code Money} instance in USD currency with provided values of
+     * {@link Money#units_} and {@link Money#nanos_}.
+     */
     public static Money usd(long units, int nanos) {
         return moneyOf(units, nanos, Currency.USD);
     }
 
+    /**
+     * Creates the {@code Money} instance in USD currency
+     * with a provided value of {@link Money#units_}.
+     */
     public static Money usd(long units) {
         return moneyOf(units, Currency.USD);
     }

--- a/model/src/test/java/io/spine/examples/shareaware/given/package-info.java
+++ b/model/src/test/java/io/spine/examples/shareaware/given/package-info.java
@@ -24,51 +24,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.shareaware.server.given;
+/**
+ * Test environment classes for testing
+ * {@code io.spine.examples.shareaware} package.
+ */
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.examples.shareaware.given;
 
-import io.spine.money.Currency;
-import io.spine.money.Money;
-
-public final class GivenMoney {
-
-    /**
-     * Prevents instantiation of this utility class.
-     */
-    private GivenMoney() {
-    }
-
-    public static Money zero() {
-        return Money
-                .newBuilder()
-                .setCurrency(Currency.USD)
-                .setUnits(0)
-                .setNanos(0)
-                .vBuild();
-    }
-
-    public static Money moneyOf(long units, Currency currency) {
-        return Money
-                .newBuilder()
-                .setCurrency(currency)
-                .setUnits(units)
-                .setNanos(0)
-                .vBuild();
-    }
-
-    public static Money moneyOf(long units, int nanos, Currency currency) {
-        return Money
-                .newBuilder()
-                .setCurrency(currency)
-                .setUnits(units)
-                .setNanos(nanos)
-                .vBuild();
-    }
-
-    public static Money usd(long units, int nanos) {
-        return moneyOf(units, nanos, Currency.USD);
-    }
-
-    public static Money usd(long units) {
-        return moneyOf(units, Currency.USD);
-    }
-}
+import javax.annotation.CheckReturnValue;
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesPurchaseProcess.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesPurchaseProcess.java
@@ -48,12 +48,9 @@ import io.spine.examples.shareaware.wallet.event.MoneyReservationCanceled;
 import io.spine.examples.shareaware.wallet.event.MoneyReserved;
 import io.spine.examples.shareaware.wallet.event.ReservedMoneyDebited;
 import io.spine.examples.shareaware.wallet.rejection.Rejections.InsufficientFunds;
-import io.spine.money.Money;
 import io.spine.server.command.Command;
 import io.spine.server.event.React;
 import io.spine.server.procman.ProcessManager;
-
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.*;
 
 /**
  * Coordinates the shares purchase from the market.
@@ -67,13 +64,11 @@ final class SharesPurchaseProcess
     @Command
     ReserveMoney on(PurchaseShares c) {
         initState(c);
-        Money purchasePrice =
-                multiply(c.getSharePrice(), c.getQuantity());
         return ReserveMoney
                 .newBuilder()
                 .setWallet(walletId(c.getPurchaser()))
                 .setOperation(operationId(c.getPurchaseProcess()))
-                .setAmount(purchasePrice)
+                .setAmount(c.operationPrice())
                 .vBuild();
     }
 

--- a/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesPurchaseProcess.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesPurchaseProcess.java
@@ -68,7 +68,7 @@ final class SharesPurchaseProcess
                 .newBuilder()
                 .setWallet(walletId(c.getPurchaser()))
                 .setOperation(operationId(c.getPurchaseProcess()))
-                .setAmount(c.operationPrice())
+                .setAmount(c.totalCost())
                 .vBuild();
     }
 

--- a/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesSaleProcess.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesSaleProcess.java
@@ -80,7 +80,7 @@ final class SharesSaleProcess
                 .setId(c.getSaleProcess())
                 .setShare(c.getShare())
                 .setSeller(c.getSeller())
-                .setPrice(c.getPrice());
+                .setPrice(c.getSharePrice());
     }
 
     /**

--- a/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesSaleProcess.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesSaleProcess.java
@@ -80,7 +80,7 @@ final class SharesSaleProcess
                 .setId(c.getSaleProcess())
                 .setShare(c.getShare())
                 .setSeller(c.getSeller())
-                .setPrice(c.getSharePrice());
+                .setPrice(c.getPrice());
     }
 
     /**

--- a/server/src/main/java/io/spine/examples/shareaware/server/market/MarketProcess.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/market/MarketProcess.java
@@ -42,7 +42,7 @@ import io.spine.money.Money;
 import io.spine.server.command.Assign;
 import io.spine.server.procman.ProcessManager;
 
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.*;
+import static io.spine.examples.shareaware.MoneyCalculator.*;
 
 /**
  * The imitation of the shares market.

--- a/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletAggregate.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletAggregate.java
@@ -45,7 +45,7 @@ import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
 
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.*;
+import static io.spine.examples.shareaware.MoneyCalculator.*;
 
 /**
  * The Wallet aggregate is responsible for managing the money

--- a/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletAggregate.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletAggregate.java
@@ -83,18 +83,18 @@ public final class WalletAggregate extends Aggregate<WalletId, Wallet, Wallet.Bu
 
     @Assign
     BalanceRecharged handle(RechargeBalance c) {
+        Money newBalance = sum(state().getBalance(), c.getMoneyAmount());
         return BalanceRecharged
                 .newBuilder()
                 .setWallet(c.getWallet())
-                .setMoneyAmount(c.getMoneyAmount())
+                .setCurrentBalance(newBalance)
                 .setOperation(c.getOperation())
                 .vBuild();
     }
 
     @Apply
     private void event(BalanceRecharged e) {
-        Money newBalance = sum(state().getBalance(), e.getMoneyAmount());
-        builder().setBalance(newBalance);
+        builder().setBalance(e.getCurrentBalance());
     }
 
     @Assign

--- a/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletBalanceProjection.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletBalanceProjection.java
@@ -29,6 +29,7 @@ package io.spine.examples.shareaware.server.wallet;
 import io.spine.core.Subscribe;
 import io.spine.examples.shareaware.WalletId;
 import io.spine.examples.shareaware.wallet.WalletBalance;
+import io.spine.examples.shareaware.wallet.event.BalanceRecharged;
 import io.spine.examples.shareaware.wallet.event.MoneyWithdrawn;
 import io.spine.examples.shareaware.wallet.event.WalletCreated;
 import io.spine.examples.shareaware.wallet.event.WalletReplenished;
@@ -51,9 +52,8 @@ final class WalletBalanceProjection
     }
 
     @Subscribe
-    void on(WalletReplenished e) {
-        Money replenishedBalance = sum(state().getBalance(), e.getMoneyAmount());
-        builder().setBalance(replenishedBalance);
+    void on(BalanceRecharged e) {
+        builder().setBalance(e.getCurrentBalance());
     }
 
     @Subscribe

--- a/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletBalanceProjection.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletBalanceProjection.java
@@ -30,13 +30,10 @@ import io.spine.core.Subscribe;
 import io.spine.examples.shareaware.WalletId;
 import io.spine.examples.shareaware.wallet.WalletBalance;
 import io.spine.examples.shareaware.wallet.event.BalanceRecharged;
-import io.spine.examples.shareaware.wallet.event.MoneyWithdrawn;
+import io.spine.examples.shareaware.wallet.event.ReservedMoneyDebited;
 import io.spine.examples.shareaware.wallet.event.WalletCreated;
-import io.spine.examples.shareaware.wallet.event.WalletReplenished;
-import io.spine.money.Money;
 import io.spine.server.projection.Projection;
 
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.*;
 
 /**
  * Manages instances of {@code WalletBalance} projections.
@@ -57,7 +54,7 @@ final class WalletBalanceProjection
     }
 
     @Subscribe
-    void on(MoneyWithdrawn e) {
+    void on(ReservedMoneyDebited e) {
         builder().setBalance(e.getCurrentBalance());
     }
 }

--- a/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletReplenishmentProcess.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletReplenishmentProcess.java
@@ -73,7 +73,8 @@ final class WalletReplenishmentProcess
     private void initState(ReplenishWallet c) {
         builder()
                 .setId(c.getReplenishment())
-                .setWallet(c.getWallet());
+                .setWallet(c.getWallet())
+                .setMoneyAmount(c.getMoneyAmount());
     }
 
     /**
@@ -100,7 +101,7 @@ final class WalletReplenishmentProcess
                 .newBuilder()
                 .setReplenishment(state().getId())
                 .setWallet(e.getWallet())
-                .setMoneyAmount(e.getMoneyAmount())
+                .setMoneyAmount(state().getMoneyAmount())
                 .vBuild();
     }
 

--- a/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletReplenishmentProcess.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletReplenishmentProcess.java
@@ -74,7 +74,7 @@ final class WalletReplenishmentProcess
         builder()
                 .setId(c.getReplenishment())
                 .setWallet(c.getWallet())
-                .setMoneyAmount(c.getMoneyAmount());
+                .setAmount(c.getMoneyAmount());
     }
 
     /**
@@ -101,7 +101,7 @@ final class WalletReplenishmentProcess
                 .newBuilder()
                 .setReplenishment(state().getId())
                 .setWallet(e.getWallet())
-                .setMoneyAmount(state().getMoneyAmount())
+                .setMoneyAmount(state().getAmount())
                 .vBuild();
     }
 

--- a/server/src/test/java/io/spine/examples/shareaware/MoneyCalculatorAbstractTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/MoneyCalculatorAbstractTest.java
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.shareaware.server.wallet;
+package io.spine.examples.shareaware;
 
 import com.google.common.testing.NullPointerTester;
 import io.spine.money.Currency;

--- a/server/src/test/java/io/spine/examples/shareaware/MoneyCalculatorTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/MoneyCalculatorTest.java
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.shareaware.server.wallet;
+package io.spine.examples.shareaware;
 
 import io.spine.money.Money;
 import org.junit.jupiter.api.DisplayName;

--- a/server/src/test/java/io/spine/examples/shareaware/server/given/GivenMoney.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/given/GivenMoney.java
@@ -1,3 +1,29 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package io.spine.examples.shareaware.server.given;
 
 import io.spine.money.Currency;

--- a/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestContext.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestContext.java
@@ -36,18 +36,19 @@ import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.DefaultRepository;
 
-public final class WithdrawalTestContext {
+public final class WalletTestContext {
 
-    private static final String NAME = "WithdrawalTest";
+    private static final String NAME = "WalletTest";
 
     /**
      * Prevents instantiation of this class.
      */
-    private WithdrawalTestContext() {
+    private WalletTestContext() {
     }
 
     /**
-     * Creates the {@link BoundedContextBuilder} for testing the wallet withdrawal flow.
+     * Creates the {@link BoundedContextBuilder} for testing
+     * the wallet withdrawal/replenishment flow.
      *
      * <p>Replaces {@code PaymentGatewayProcess} on {@code RejectingPaymentProcess}
      * for rejection control.

--- a/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
@@ -143,6 +143,7 @@ public final class WalletTestEnv {
                 .newBuilder()
                 .setWallet(command.getWallet())
                 .setId(command.getReplenishment())
+                .setAmount(command.getMoneyAmount())
                 .vBuild();
     }
 
@@ -185,10 +186,10 @@ public final class WalletTestEnv {
     }
 
     public static WalletNotReplenished
-    walletNotReplenishedBy(ReplenishmentId replenishmentProcess) {
+    walletNotReplenishedAfter(ReplenishWallet command) {
         return WalletNotReplenished
                 .newBuilder()
-                .setReplenishment(replenishmentProcess)
+                .setReplenishment(command.getReplenishment())
                 .vBuild();
     }
 

--- a/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
@@ -120,7 +120,7 @@ public final class WalletTestEnv {
         return BalanceRecharged
                 .newBuilder()
                 .setWallet(wallet)
-                .setMoneyAmount(command.getMoneyAmount())
+                .setCurrentBalance(command.getMoneyAmount())
                 .setOperation(operationId(command))
                 .vBuild();
     }

--- a/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
@@ -10,7 +10,7 @@ import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyToUser;
 import io.spine.examples.shareaware.paymentgateway.event.MoneyTransferredToUser;
 import io.spine.examples.shareaware.paymentgateway.rejection.Rejections.MoneyCannotBeTransferredFromUser;
 import io.spine.examples.shareaware.server.paymentgateway.PaymentGatewayProcess;
-import io.spine.examples.shareaware.server.wallet.MoneyCalculator;
+import io.spine.examples.shareaware.MoneyCalculator;
 import io.spine.examples.shareaware.wallet.Iban;
 import io.spine.examples.shareaware.wallet.Wallet;
 import io.spine.examples.shareaware.wallet.WalletBalance;
@@ -39,8 +39,8 @@ import io.spine.testing.core.given.GivenUserId;
 import io.spine.testing.server.blackbox.BlackBoxContext;
 
 import static io.spine.examples.shareaware.server.given.GivenMoney.moneyOf;
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.subtract;
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.sum;
+import static io.spine.examples.shareaware.MoneyCalculator.subtract;
+import static io.spine.examples.shareaware.MoneyCalculator.sum;
 
 public final class WalletTestEnv {
 

--- a/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
@@ -5,6 +5,7 @@ import io.spine.examples.shareaware.ReplenishmentId;
 import io.spine.examples.shareaware.ReplenishmentOperationId;
 import io.spine.examples.shareaware.WalletId;
 import io.spine.examples.shareaware.WithdrawalId;
+import io.spine.examples.shareaware.given.GivenMoney;
 import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyFromUser;
 import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyToUser;
 import io.spine.examples.shareaware.paymentgateway.event.MoneyTransferredToUser;
@@ -38,7 +39,7 @@ import io.spine.money.Money;
 import io.spine.testing.core.given.GivenUserId;
 import io.spine.testing.server.blackbox.BlackBoxContext;
 
-import static io.spine.examples.shareaware.server.given.GivenMoney.moneyOf;
+import static io.spine.examples.shareaware.given.GivenMoney.moneyOf;
 import static io.spine.examples.shareaware.MoneyCalculator.subtract;
 import static io.spine.examples.shareaware.MoneyCalculator.sum;
 

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesPurchaseTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesPurchaseTest.java
@@ -43,6 +43,7 @@ import io.spine.examples.shareaware.server.FreshContextTest;
 import io.spine.examples.shareaware.server.investment.given.InvestmentTestContext;
 import io.spine.examples.shareaware.server.investment.given.RejectingMarket;
 import io.spine.examples.shareaware.wallet.Wallet;
+import io.spine.examples.shareaware.wallet.WalletBalance;
 import io.spine.examples.shareaware.wallet.command.CancelMoneyReservation;
 import io.spine.examples.shareaware.wallet.command.DebitReservedMoney;
 import io.spine.examples.shareaware.wallet.command.ReserveMoney;
@@ -313,5 +314,20 @@ public final class SharesPurchaseTest extends FreshContextTest {
         InvestmentView expected = investmentViewAfter(firstPurchase, secondPurchase);
 
         context().assertState(expected.getId(), expected);
+    }
+
+    @Test
+    @DisplayName("reduce the balance value in the `WalletBalance` projection")
+    void reduceWalletBalance() {
+        Wallet wallet = setUpReplenishedWallet(context());
+        UserId user = wallet.getId()
+                            .getOwner();
+        ShareId share = ShareId.generate();
+        PurchaseShares firstPurchase = purchaseSharesFor(user, share);
+        PurchaseShares secondPurchase = purchaseSharesFor(user, share);
+        context().receivesCommands(firstPurchase, secondPurchase);
+        WalletBalance expected = walletBalanceAfter(firstPurchase, secondPurchase, wallet);
+
+        context().assertState(wallet.getId(), expected);
     }
 }

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesSaleTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesSaleTest.java
@@ -185,6 +185,7 @@ public class SharesSaleTest extends FreshContextTest {
     }
 
     @Test
+    @DisplayName("increase the amount of money in the `WalletBalance` projection")
     void increaseWalletBalance() {
         Wallet wallet = setUpReplenishedWallet(context());
         UserId user = wallet.getId()

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesSaleTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesSaleTest.java
@@ -46,6 +46,7 @@ import io.spine.examples.shareaware.server.FreshContextTest;
 import io.spine.examples.shareaware.server.investment.given.InvestmentTestContext;
 import io.spine.examples.shareaware.server.investment.given.RejectingMarket;
 import io.spine.examples.shareaware.wallet.Wallet;
+import io.spine.examples.shareaware.wallet.WalletBalance;
 import io.spine.examples.shareaware.wallet.command.RechargeBalance;
 import io.spine.examples.shareaware.wallet.event.BalanceRecharged;
 import io.spine.server.BoundedContextBuilder;
@@ -181,6 +182,21 @@ public class SharesSaleTest extends FreshContextTest {
         InvestmentView expected = investmentViewAfter(firstSale, secondSale, investment);
 
         context().assertState(investment.getId(), expected);
+    }
+
+    @Test
+    void increaseWalletBalance() {
+        Wallet wallet = setUpReplenishedWallet(context());
+        UserId user = wallet.getId()
+                            .getOwner();
+        PurchaseShares purchaseCommand = purchaseSharesFor(user);
+        context().receivesCommand(purchaseCommand);
+
+        SellShares sellCommand = sellShareAfter(purchaseCommand);
+        context().receivesCommand(sellCommand);
+        WalletBalance expected = walletBalanceAfter(purchaseCommand, sellCommand, wallet);
+
+        context().assertState(wallet.getId(), expected);
     }
 
     @Test

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesSaleTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesSaleTest.java
@@ -96,7 +96,8 @@ public class SharesSaleTest extends FreshContextTest {
 
             SellShares sellCommand = sellShareAfter(purchaseCommand);
             context().receivesCommand(sellCommand);
-            BalanceRecharged expected = balanceRechargedBy(sellCommand);
+            BalanceRecharged expected =
+                    balanceRechargedAfter(sellCommand, purchaseCommand, wallet);
 
             context().assertEvents()
                      .withType(BalanceRecharged.class)

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
@@ -65,9 +65,9 @@ import io.spine.testing.server.blackbox.BlackBoxContext;
 
 import static io.spine.examples.shareaware.server.given.GivenMoney.usd;
 import static io.spine.examples.shareaware.server.given.WalletTestEnv.*;
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.multiply;
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.subtract;
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.sum;
+import static io.spine.examples.shareaware.MoneyCalculator.multiply;
+import static io.spine.examples.shareaware.MoneyCalculator.subtract;
+import static io.spine.examples.shareaware.MoneyCalculator.sum;
 
 public final class InvestmentTestEnv {
 

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
@@ -95,7 +95,7 @@ public final class InvestmentTestEnv {
                                      PurchaseShares secondPurchase,
                                      Wallet wallet) {
         Money totalPrice = sum(firstPurchase.totalCost(),
-                                        secondPurchase.totalCost());
+                               secondPurchase.totalCost());
         Money newBalance = subtract(wallet.getBalance(), totalPrice);
         return wallet
                 .toBuilder()
@@ -344,7 +344,7 @@ public final class InvestmentTestEnv {
                                                    PurchaseShares secondPurchase,
                                                    Wallet wallet) {
         Money totalPrice = sum(firstPurchase.totalCost(),
-                                        secondPurchase.totalCost());
+                               secondPurchase.totalCost());
         Money currentBalance = subtract(wallet.getBalance(), totalPrice);
         return WalletBalance
                 .newBuilder()

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
@@ -94,8 +94,8 @@ public final class InvestmentTestEnv {
     public static Wallet walletAfter(PurchaseShares firstPurchase,
                                      PurchaseShares secondPurchase,
                                      Wallet wallet) {
-        Money commonPurchasePrice = sum(firstPurchase.operationPrice(),
-                                        secondPurchase.operationPrice());
+        Money commonPurchasePrice = sum(firstPurchase.totalCost(),
+                                        secondPurchase.totalCost());
         Money newBalance = subtract(wallet.getBalance(), commonPurchasePrice);
         return wallet
                 .toBuilder()
@@ -108,13 +108,13 @@ public final class InvestmentTestEnv {
                 .newBuilder()
                 .setOperation(operationId(command.getPurchaseProcess()))
                 .setWallet(walletId(command.getPurchaser()))
-                .setAmount(command.operationPrice())
+                .setAmount(command.totalCost())
                 .vBuild();
     }
 
     public static ReservedMoneyDebited
     reservedMoneyDebitedBy(PurchaseShares command, Wallet wallet) {
-        Money newBalance = subtract(wallet.getBalance(), command.operationPrice());
+        Money newBalance = subtract(wallet.getBalance(), command.totalCost());
         return ReservedMoneyDebited
                 .newBuilder()
                 .setWallet(wallet.getId())
@@ -138,7 +138,7 @@ public final class InvestmentTestEnv {
                 .newBuilder()
                 .setWallet(wallet)
                 .setOperation(operationId(command.getPurchaseProcess()))
-                .setAmount(command.operationPrice())
+                .setAmount(command.totalCost())
                 .vBuild();
     }
 
@@ -147,7 +147,7 @@ public final class InvestmentTestEnv {
                 .newBuilder()
                 .setWallet(walletId(command.getPurchaser()))
                 .setOperation(operationId(command.getPurchaseProcess()))
-                .setAmount(command.operationPrice())
+                .setAmount(command.totalCost())
                 .vBuild();
     }
 
@@ -343,8 +343,8 @@ public final class InvestmentTestEnv {
     public static WalletBalance walletBalanceAfter(PurchaseShares firstPurchase,
                                                    PurchaseShares secondPurchase,
                                                    Wallet wallet) {
-        Money commonPurchasePrice = sum(firstPurchase.operationPrice(),
-                                        secondPurchase.operationPrice());
+        Money commonPurchasePrice = sum(firstPurchase.totalCost(),
+                                        secondPurchase.totalCost());
         Money currentBalance = subtract(wallet.getBalance(), commonPurchasePrice);
         return WalletBalance
                 .newBuilder()

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
@@ -52,6 +52,7 @@ import io.spine.examples.shareaware.investment.rejection.Rejections.Insufficient
 import io.spine.examples.shareaware.market.command.ObtainShares;
 import io.spine.examples.shareaware.server.market.MarketProcess;
 import io.spine.examples.shareaware.wallet.Wallet;
+import io.spine.examples.shareaware.wallet.WalletBalance;
 import io.spine.examples.shareaware.wallet.command.CancelMoneyReservation;
 import io.spine.examples.shareaware.wallet.command.DebitReservedMoney;
 import io.spine.examples.shareaware.wallet.command.ReserveMoney;
@@ -344,6 +345,22 @@ public final class InvestmentTestEnv {
                 .newBuilder()
                 .setId(investmentId(user, share))
                 .setSharesAvailable(sharesAvailable)
+                .vBuild();
+    }
+
+    public static WalletBalance walletBalanceAfter(PurchaseShares firstPurchase,
+                                                   PurchaseShares secondPurchase,
+                                                   Wallet wallet) {
+        Money firstPurchasePrice = multiply(firstPurchase.getSharePrice(),
+                                            firstPurchase.getQuantity());
+        Money secondPurchasePrice = multiply(secondPurchase.getSharePrice(),
+                                             secondPurchase.getQuantity());
+        Money commonPurchasePrice = sum(firstPurchasePrice, secondPurchasePrice);
+        Money currentBalance = subtract(wallet.getBalance(), commonPurchasePrice);
+        return WalletBalance
+                .newBuilder()
+                .setId(wallet.getId())
+                .setBalance(currentBalance)
                 .vBuild();
     }
 

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
@@ -86,7 +86,7 @@ public final class InvestmentTestEnv {
                 .setShare(share)
                 .setPurchaseProcess(PurchaseId.generate())
                 .setQuantity(5)
-                .setSharePrice(usd(20))
+                .setPrice(usd(20))
                 .setPurchaser(purchaser)
                 .vBuild();
     }

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
@@ -65,7 +65,6 @@ import io.spine.testing.server.blackbox.BlackBoxContext;
 
 import static io.spine.examples.shareaware.server.given.GivenMoney.usd;
 import static io.spine.examples.shareaware.server.given.WalletTestEnv.*;
-import static io.spine.examples.shareaware.MoneyCalculator.multiply;
 import static io.spine.examples.shareaware.MoneyCalculator.subtract;
 import static io.spine.examples.shareaware.MoneyCalculator.sum;
 
@@ -95,11 +94,8 @@ public final class InvestmentTestEnv {
     public static Wallet walletAfter(PurchaseShares firstPurchase,
                                      PurchaseShares secondPurchase,
                                      Wallet wallet) {
-        Money firstPurchasePrice = multiply(firstPurchase.getSharePrice(),
-                                            firstPurchase.getQuantity());
-        Money secondPurchasePrice = multiply(secondPurchase.getSharePrice(),
-                                             secondPurchase.getQuantity());
-        Money commonPurchasePrice = sum(firstPurchasePrice, secondPurchasePrice);
+        Money commonPurchasePrice = sum(firstPurchase.operationPrice(),
+                                        secondPurchase.operationPrice());
         Money newBalance = subtract(wallet.getBalance(), commonPurchasePrice);
         return wallet
                 .toBuilder()
@@ -108,19 +104,17 @@ public final class InvestmentTestEnv {
     }
 
     public static MoneyReserved moneyReservedBy(PurchaseShares command) {
-        Money purchasePrice = multiply(command.getSharePrice(), command.getQuantity());
         return MoneyReserved
                 .newBuilder()
                 .setOperation(operationId(command.getPurchaseProcess()))
                 .setWallet(walletId(command.getPurchaser()))
-                .setAmount(purchasePrice)
+                .setAmount(command.operationPrice())
                 .vBuild();
     }
 
     public static ReservedMoneyDebited
     reservedMoneyDebitedBy(PurchaseShares command, Wallet wallet) {
-        Money purchasePrice = multiply(command.getSharePrice(), command.getQuantity());
-        Money newBalance = subtract(wallet.getBalance(), purchasePrice);
+        Money newBalance = subtract(wallet.getBalance(), command.operationPrice());
         return ReservedMoneyDebited
                 .newBuilder()
                 .setWallet(wallet.getId())
@@ -140,22 +134,20 @@ public final class InvestmentTestEnv {
     }
 
     public static InsufficientFunds insufficientFundsIn(WalletId wallet, PurchaseShares command) {
-        Money purchasePrice = multiply(command.getSharePrice(), command.getQuantity());
         return InsufficientFunds
                 .newBuilder()
                 .setWallet(wallet)
                 .setOperation(operationId(command.getPurchaseProcess()))
-                .setAmount(purchasePrice)
+                .setAmount(command.operationPrice())
                 .vBuild();
     }
 
     public static ReserveMoney reserveMoneyInitiatedBy(PurchaseShares command) {
-        Money purchasePrice = multiply(command.getSharePrice(), command.getQuantity());
         return ReserveMoney
                 .newBuilder()
                 .setWallet(walletId(command.getPurchaser()))
                 .setOperation(operationId(command.getPurchaseProcess()))
-                .setAmount(purchasePrice)
+                .setAmount(command.operationPrice())
                 .vBuild();
     }
 
@@ -351,11 +343,8 @@ public final class InvestmentTestEnv {
     public static WalletBalance walletBalanceAfter(PurchaseShares firstPurchase,
                                                    PurchaseShares secondPurchase,
                                                    Wallet wallet) {
-        Money firstPurchasePrice = multiply(firstPurchase.getSharePrice(),
-                                            firstPurchase.getQuantity());
-        Money secondPurchasePrice = multiply(secondPurchase.getSharePrice(),
-                                             secondPurchase.getQuantity());
-        Money commonPurchasePrice = sum(firstPurchasePrice, secondPurchasePrice);
+        Money commonPurchasePrice = sum(firstPurchase.operationPrice(),
+                                        secondPurchase.operationPrice());
         Money currentBalance = subtract(wallet.getBalance(), commonPurchasePrice);
         return WalletBalance
                 .newBuilder()

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
@@ -63,7 +63,7 @@ import io.spine.examples.shareaware.wallet.rejection.Rejections.InsufficientFund
 import io.spine.money.Money;
 import io.spine.testing.server.blackbox.BlackBoxContext;
 
-import static io.spine.examples.shareaware.server.given.GivenMoney.usd;
+import static io.spine.examples.shareaware.given.GivenMoney.usd;
 import static io.spine.examples.shareaware.server.given.WalletTestEnv.*;
 import static io.spine.examples.shareaware.MoneyCalculator.subtract;
 import static io.spine.examples.shareaware.MoneyCalculator.sum;
@@ -94,9 +94,9 @@ public final class InvestmentTestEnv {
     public static Wallet walletAfter(PurchaseShares firstPurchase,
                                      PurchaseShares secondPurchase,
                                      Wallet wallet) {
-        Money commonPurchasePrice = sum(firstPurchase.totalCost(),
+        Money totalPrice = sum(firstPurchase.totalCost(),
                                         secondPurchase.totalCost());
-        Money newBalance = subtract(wallet.getBalance(), commonPurchasePrice);
+        Money newBalance = subtract(wallet.getBalance(), totalPrice);
         return wallet
                 .toBuilder()
                 .setBalance(newBalance)
@@ -343,9 +343,9 @@ public final class InvestmentTestEnv {
     public static WalletBalance walletBalanceAfter(PurchaseShares firstPurchase,
                                                    PurchaseShares secondPurchase,
                                                    Wallet wallet) {
-        Money commonPurchasePrice = sum(firstPurchase.totalCost(),
+        Money totalPrice = sum(firstPurchase.totalCost(),
                                         secondPurchase.totalCost());
-        Money currentBalance = subtract(wallet.getBalance(), commonPurchasePrice);
+        Money currentBalance = subtract(wallet.getBalance(), totalPrice);
         return WalletBalance
                 .newBuilder()
                 .setId(wallet.getId())

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/RejectingMarket.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/RejectingMarket.java
@@ -38,7 +38,7 @@ import io.spine.money.Money;
 import io.spine.server.command.Assign;
 import io.spine.server.procman.ProcessManager;
 
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.multiply;
+import static io.spine.examples.shareaware.MoneyCalculator.multiply;
 
 /**
  * The test imitation of {@code MarketProcess} with rejection mode.

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
@@ -47,9 +47,9 @@ import io.spine.examples.shareaware.wallet.command.RechargeBalance;
 import io.spine.examples.shareaware.wallet.event.BalanceRecharged;
 import io.spine.money.Money;
 
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.multiply;
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.subtract;
-import static io.spine.examples.shareaware.server.wallet.MoneyCalculator.sum;
+import static io.spine.examples.shareaware.MoneyCalculator.multiply;
+import static io.spine.examples.shareaware.MoneyCalculator.subtract;
+import static io.spine.examples.shareaware.MoneyCalculator.sum;
 
 public final class SharesSaleTestEnv {
 
@@ -88,7 +88,7 @@ public final class SharesSaleTestEnv {
                 .setSeller(user)
                 .setShare(share)
                 .setQuantity(quantity)
-                .setPrice(GivenMoney.usd(20))
+                .setSharePrice(GivenMoney.usd(20))
                 .vBuild();
     }
 
@@ -99,12 +99,12 @@ public final class SharesSaleTestEnv {
         Money currentBalance = subtract(wallet.getBalance(), purchasePrice);
         return wallet
                 .toBuilder()
-                .setBalance(sum(currentBalance, sale.getPrice()))
+                .setBalance(sum(currentBalance, sale.getSharePrice()))
                 .vBuild();
     }
 
     public static BalanceRecharged balanceRechargedBy(SellShares command, Wallet wallet) {
-        Money sellPrice = multiply(command.getPrice(), command.getQuantity());
+        Money sellPrice = multiply(command.getSharePrice(), command.getQuantity());
         Money currentBalance = sum(wallet.getBalance(), sellPrice);
         return balanceRecharged(command, currentBalance);
     }
@@ -115,7 +115,7 @@ public final class SharesSaleTestEnv {
         Money purchasePrice = multiply(purchaseCommand.getSharePrice(),
                                        purchaseCommand.getQuantity());
         Money balanceAfterPurchase = subtract(wallet.getBalance(), purchasePrice);
-        Money sellPrice = multiply(command.getPrice(), command.getQuantity());
+        Money sellPrice = multiply(command.getSharePrice(), command.getQuantity());
         Money currentBalance = sum(balanceAfterPurchase, sellPrice);
         return balanceRecharged(command, currentBalance);
     }
@@ -135,7 +135,7 @@ public final class SharesSaleTestEnv {
                 .setId(command.getSaleProcess())
                 .setSeller(command.getSeller())
                 .setShare(command.getShare())
-                .setPrice(command.getPrice())
+                .setPrice(command.getSharePrice())
                 .vBuild();
     }
 
@@ -145,13 +145,13 @@ public final class SharesSaleTestEnv {
                 .setMarket(MarketProcess.ID)
                 .setSaleProcess(command.getSaleProcess())
                 .setShare(command.getShare())
-                .setPrice(command.getPrice())
+                .setPrice(command.getSharePrice())
                 .setQuantity(command.getQuantity())
                 .vBuild();
     }
 
     public static RechargeBalance rechargeBalanceWith(SellShares command) {
-        Money sellPrice = multiply(command.getPrice(), command.getQuantity());
+        Money sellPrice = multiply(command.getSharePrice(), command.getQuantity());
         return RechargeBalance
                 .newBuilder()
                 .setOperation(operationId(command.getSaleProcess()))
@@ -167,7 +167,7 @@ public final class SharesSaleTestEnv {
                 .setSaleProcess(command.getSaleProcess())
                 .setShare(command.getShare())
                 .setSeller(command.getSeller())
-                .setPrice(command.getPrice())
+                .setPrice(command.getSharePrice())
                 .setSharesAvailable(sharesAvailable)
                 .vBuild();
     }
@@ -198,7 +198,7 @@ public final class SharesSaleTestEnv {
         Money purchasePrice = multiply(purchaseCommand.getSharePrice(),
                                        purchaseCommand.getQuantity());
         Money balanceAfterPurchase = subtract(wallet.getBalance(), purchasePrice);
-        Money sellPrice = multiply(sellCommand.getPrice(), sellCommand.getQuantity());
+        Money sellPrice = multiply(sellCommand.getSharePrice(), sellCommand.getQuantity());
         Money currentBalance = sum(balanceAfterPurchase, sellPrice);
         return WalletBalance
                 .newBuilder()

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
@@ -94,15 +94,15 @@ public final class SharesSaleTestEnv {
     public static Wallet walletAfter(PurchaseShares purchaseCommand,
                                      SellShares saleCommand,
                                      Wallet wallet) {
-        Money currentBalance = subtract(wallet.getBalance(), purchaseCommand.operationPrice());
+        Money currentBalance = subtract(wallet.getBalance(), purchaseCommand.totalCost());
         return wallet
                 .toBuilder()
-                .setBalance(sum(currentBalance, saleCommand.operationPrice()))
+                .setBalance(sum(currentBalance, saleCommand.totalCost()))
                 .vBuild();
     }
 
     public static BalanceRecharged balanceRechargedBy(SellShares command, Wallet wallet) {
-        Money currentBalance = sum(wallet.getBalance(), command.operationPrice());
+        Money currentBalance = sum(wallet.getBalance(), command.totalCost());
         return balanceRecharged(command, currentBalance);
     }
 
@@ -110,8 +110,8 @@ public final class SharesSaleTestEnv {
                                                          PurchaseShares purchaseCommand,
                                                          Wallet wallet) {
         Money balanceAfterPurchase = subtract(wallet.getBalance(),
-                                              purchaseCommand.operationPrice());
-        Money currentBalance = sum(balanceAfterPurchase, saleCommand.operationPrice());
+                                              purchaseCommand.totalCost());
+        Money currentBalance = sum(balanceAfterPurchase, saleCommand.totalCost());
         return balanceRecharged(saleCommand, currentBalance);
     }
 
@@ -150,7 +150,7 @@ public final class SharesSaleTestEnv {
                 .newBuilder()
                 .setOperation(operationId(command.getSaleProcess()))
                 .setWallet(walletId(command.getSeller()))
-                .setMoneyAmount(command.operationPrice())
+                .setMoneyAmount(command.totalCost())
                 .vBuild();
     }
 
@@ -190,8 +190,8 @@ public final class SharesSaleTestEnv {
                                                    SellShares sellCommand,
                                                    Wallet wallet) {
         Money balanceAfterPurchase =
-                subtract(wallet.getBalance(), purchaseCommand.operationPrice());
-        Money currentBalance = sum(balanceAfterPurchase, sellCommand.operationPrice());
+                subtract(wallet.getBalance(), purchaseCommand.totalCost());
+        Money currentBalance = sum(balanceAfterPurchase, sellCommand.totalCost());
         return WalletBalance
                 .newBuilder()
                 .setId(wallet.getId())

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
@@ -39,7 +39,7 @@ import io.spine.examples.shareaware.investment.command.SellShares;
 import io.spine.examples.shareaware.investment.event.SharesSaleFailed;
 import io.spine.examples.shareaware.investment.event.SharesSold;
 import io.spine.examples.shareaware.market.command.SellSharesOnMarket;
-import io.spine.examples.shareaware.server.given.GivenMoney;
+import io.spine.examples.shareaware.given.GivenMoney;
 import io.spine.examples.shareaware.server.market.MarketProcess;
 import io.spine.examples.shareaware.wallet.Wallet;
 import io.spine.examples.shareaware.wallet.WalletBalance;

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
@@ -102,13 +102,29 @@ public final class SharesSaleTestEnv {
                 .vBuild();
     }
 
-    public static BalanceRecharged balanceRechargedBy(SellShares command) {
+    public static BalanceRecharged balanceRechargedBy(SellShares command, Wallet wallet) {
         Money sellPrice = multiply(command.getPrice(), command.getQuantity());
+        Money currentBalance = sum(wallet.getBalance(), sellPrice);
+        return balanceRecharged(command, currentBalance);
+    }
+
+    public static BalanceRecharged balanceRechargedAfter(SellShares command,
+                                                         PurchaseShares purchaseCommand,
+                                                         Wallet wallet) {
+        Money purchasePrice = multiply(purchaseCommand.getSharePrice(),
+                                       purchaseCommand.getQuantity());
+        Money balanceAfterPurchase = subtract(wallet.getBalance(), purchasePrice);
+        Money sellPrice = multiply(command.getPrice(), command.getQuantity());
+        Money currentBalance = sum(balanceAfterPurchase, sellPrice);
+        return balanceRecharged(command, currentBalance);
+    }
+
+    private static BalanceRecharged balanceRecharged(SellShares command, Money balance) {
         return BalanceRecharged
                 .newBuilder()
                 .setWallet(walletId(command.getSeller()))
                 .setOperation(operationId(command.getSaleProcess()))
-                .setMoneyAmount(sellPrice)
+                .setCurrentBalance(balance)
                 .vBuild();
     }
 

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
@@ -42,6 +42,7 @@ import io.spine.examples.shareaware.market.command.SellSharesOnMarket;
 import io.spine.examples.shareaware.server.given.GivenMoney;
 import io.spine.examples.shareaware.server.market.MarketProcess;
 import io.spine.examples.shareaware.wallet.Wallet;
+import io.spine.examples.shareaware.wallet.WalletBalance;
 import io.spine.examples.shareaware.wallet.command.RechargeBalance;
 import io.spine.examples.shareaware.wallet.event.BalanceRecharged;
 import io.spine.money.Money;
@@ -188,6 +189,21 @@ public final class SharesSaleTestEnv {
                 .newBuilder()
                 .setId(investment.getId())
                 .setSharesAvailable(sharesAvailable)
+                .vBuild();
+    }
+
+    public static WalletBalance walletBalanceAfter(PurchaseShares purchaseCommand,
+                                                   SellShares sellCommand,
+                                                   Wallet wallet) {
+        Money purchasePrice = multiply(purchaseCommand.getSharePrice(),
+                                       purchaseCommand.getQuantity());
+        Money balanceAfterPurchase = subtract(wallet.getBalance(), purchasePrice);
+        Money sellPrice = multiply(sellCommand.getPrice(), sellCommand.getQuantity());
+        Money currentBalance = sum(balanceAfterPurchase, sellPrice);
+        return WalletBalance
+                .newBuilder()
+                .setId(wallet.getId())
+                .setBalance(currentBalance)
                 .vBuild();
     }
 

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
@@ -87,7 +87,7 @@ public final class SharesSaleTestEnv {
                 .setSeller(user)
                 .setShare(share)
                 .setQuantity(quantity)
-                .setSharePrice(GivenMoney.usd(20))
+                .setPrice(GivenMoney.usd(20))
                 .vBuild();
     }
 
@@ -130,7 +130,7 @@ public final class SharesSaleTestEnv {
                 .setId(command.getSaleProcess())
                 .setSeller(command.getSeller())
                 .setShare(command.getShare())
-                .setPrice(command.getSharePrice())
+                .setPrice(command.getPrice())
                 .vBuild();
     }
 
@@ -140,7 +140,7 @@ public final class SharesSaleTestEnv {
                 .setMarket(MarketProcess.ID)
                 .setSaleProcess(command.getSaleProcess())
                 .setShare(command.getShare())
-                .setPrice(command.getSharePrice())
+                .setPrice(command.getPrice())
                 .setQuantity(command.getQuantity())
                 .vBuild();
     }
@@ -161,7 +161,7 @@ public final class SharesSaleTestEnv {
                 .setSaleProcess(command.getSaleProcess())
                 .setShare(command.getShare())
                 .setSeller(command.getSeller())
-                .setPrice(command.getSharePrice())
+                .setPrice(command.getPrice())
                 .setSharesAvailable(sharesAvailable)
                 .vBuild();
     }

--- a/server/src/test/java/io/spine/examples/shareaware/server/market/given/MarketTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/market/given/MarketTestEnv.java
@@ -39,7 +39,7 @@ import io.spine.examples.shareaware.market.event.MarketClosed;
 import io.spine.examples.shareaware.market.event.MarketOpened;
 import io.spine.examples.shareaware.market.rejection.Rejections.SharesCannotBeSoldOnMarket;
 import io.spine.examples.shareaware.market.rejection.Rejections.SharesCannotBeObtained;
-import io.spine.examples.shareaware.server.given.GivenMoney;
+import io.spine.examples.shareaware.given.GivenMoney;
 import io.spine.examples.shareaware.server.market.MarketProcess;
 
 public final class MarketTestEnv {

--- a/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletBalanceProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletBalanceProjectionTest.java
@@ -28,10 +28,8 @@ package io.spine.examples.shareaware.server.wallet;
 
 import io.spine.examples.shareaware.WalletId;
 import io.spine.examples.shareaware.server.TradingContext;
-import io.spine.examples.shareaware.server.given.GivenMoney;
 import io.spine.examples.shareaware.wallet.WalletBalance;
 import io.spine.examples.shareaware.wallet.command.CreateWallet;
-import io.spine.money.Money;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.testing.server.blackbox.ContextAwareTest;
 import org.junit.jupiter.api.DisplayName;

--- a/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletTest.java
@@ -28,7 +28,7 @@ package io.spine.examples.shareaware.server.wallet;
 
 import io.spine.examples.shareaware.WalletId;
 import io.spine.examples.shareaware.server.TradingContext;
-import io.spine.examples.shareaware.server.given.GivenMoney;
+import io.spine.examples.shareaware.given.GivenMoney;
 import io.spine.examples.shareaware.wallet.Wallet;
 import io.spine.examples.shareaware.wallet.command.CreateWallet;
 import io.spine.examples.shareaware.wallet.event.WalletCreated;

--- a/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletWithdrawalTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletWithdrawalTest.java
@@ -31,7 +31,7 @@ import io.spine.examples.shareaware.WithdrawalId;
 import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyToUser;
 import io.spine.examples.shareaware.paymentgateway.event.MoneyTransferredToUser;
 import io.spine.examples.shareaware.server.FreshContextTest;
-import io.spine.examples.shareaware.server.given.WithdrawalTestContext;
+import io.spine.examples.shareaware.server.given.WalletTestContext;
 import io.spine.examples.shareaware.server.given.RejectingPaymentProcess;
 import io.spine.examples.shareaware.wallet.Wallet;
 import io.spine.examples.shareaware.wallet.WalletBalance;
@@ -59,7 +59,7 @@ public final class WalletWithdrawalTest extends FreshContextTest {
 
     @Override
     protected BoundedContextBuilder contextBuilder() {
-        return WithdrawalTestContext.newBuilder();
+        return WalletTestContext.newBuilder();
     }
 
     @Nested


### PR DESCRIPTION
This PR subscribes the `WalletBalance` projection to the `ReservedMoneyDebited` and `BalanceRecharged` events.
The process modeling of these subscriptions:
<img width="242" alt="image" src="https://user-images.githubusercontent.com/44636928/230933190-6f2342eb-ca44-4bbc-a3ee-0f20e50a73da.png">
<img width="243" alt="image" src="https://user-images.githubusercontent.com/44636928/230933256-88d2dfd6-195f-4091-b60e-fcee58bd1d58.png">
