### PR TITLE
Migrate to Java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: zulu
           cache: 'gradle'
 

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/buildSrc/src/main/kotlin/dependency-management.gradle.kts
+++ b/buildSrc/src/main/kotlin/dependency-management.gradle.kts
@@ -29,6 +29,7 @@ import io.spine.examples.shareaware.dependency.Guava
 import io.spine.examples.shareaware.dependency.JUnit
 import io.spine.examples.shareaware.dependency.Spine
 import io.spine.examples.shareaware.dependency.Truth
+import io.spine.examples.shareaware.dependency.Javax
 
 /**
  * Configures repositories, adds dependencies and forces transitive dependencies.
@@ -56,6 +57,7 @@ repositories {
 
 dependencies {
     implementation(Spine.Money.lib)
+    implementation(Javax.Annotation.Api.lib)
     implementation(Guava.lib)
     runtimeOnly(Grpc.lib)
     testImplementation(JUnit.Params.lib)

--- a/buildSrc/src/main/kotlin/error-prone-configuration.gradle.kts
+++ b/buildSrc/src/main/kotlin/error-prone-configuration.gradle.kts
@@ -41,7 +41,6 @@ plugins {
 
 dependencies {
     errorprone(ErrorProne.CorePlugin.lib)
-    errorproneJavac(ErrorProne.JavacPlugin.lib)
 }
 
 tasks.withType<JavaCompile> {

--- a/buildSrc/src/main/kotlin/io/spine/examples/shareaware/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/examples/shareaware/dependency/ErrorProne.kt
@@ -35,11 +35,6 @@ object ErrorProne {
         const val lib = "${group}:error_prone_core:${version}"
     }
 
-    object JavacPlugin {
-        const val version = "9+181-r4173-1"
-        const val lib = "${group}:javac:${version}"
-    }
-
     // https://github.com/tbroyer/gradle-errorprone-plugin
     object GradlePlugin {
         const val id = "net.ltgt.errorprone"

--- a/buildSrc/src/main/kotlin/io/spine/examples/shareaware/dependency/Javax.kt
+++ b/buildSrc/src/main/kotlin/io/spine/examples/shareaware/dependency/Javax.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.shareaware.dependency
+
+object Javax {
+
+    // https://jcp.org/en/jsr/detail?id=250
+    object Annotation {
+        object Api {
+            const val version = "1.3.2"
+            const val lib = "javax.annotation:javax.annotation-api:${version}"
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/javac-configuration.gradle.kts
+++ b/buildSrc/src/main/kotlin/javac-configuration.gradle.kts
@@ -37,7 +37,7 @@ plugins {
     java
 }
 
-val javaVersion = JavaVersion.VERSION_1_8
+val javaVersion = JavaVersion.VERSION_11
 java {
     sourceCompatibility = javaVersion
     targetCompatibility = javaVersion

--- a/model/src/main/java/io/spine/examples/shareaware/MoneyCalculator.java
+++ b/model/src/main/java/io/spine/examples/shareaware/MoneyCalculator.java
@@ -54,8 +54,8 @@ public final class MoneyCalculator {
      */
     public static Money sum(Money first, Money second) {
         checkArguments(first, second);
-        int resultNanos = first.getNanos() + second.getNanos();
-        long resultUnits = first.getUnits() + second.getUnits();
+        var resultNanos = first.getNanos() + second.getNanos();
+        var resultUnits = first.getUnits() + second.getUnits();
         if (resultNanos / NANOS_IN_UNIT >= 1) {
             resultUnits++;
             resultNanos -= NANOS_IN_UNIT;
@@ -74,8 +74,8 @@ public final class MoneyCalculator {
     public static Money subtract(Money first, Money second) {
         checkArguments(first, second);
         checkState(isGreater(first, second) || first.equals(second));
-        int resultNanos = first.getNanos() - second.getNanos();
-        long resultUnits = first.getUnits() - second.getUnits();
+        var resultNanos = first.getNanos() - second.getNanos();
+        var resultUnits = first.getUnits() - second.getUnits();
         if (resultNanos < 0) {
             resultUnits--;
             resultNanos += NANOS_IN_UNIT;
@@ -94,10 +94,10 @@ public final class MoneyCalculator {
     public static Money multiply(Money money, int multiplier) {
         checkArgument(money);
         Preconditions.checkArgument(multiplier >= 0);
-        int fullyFledgedNanos = money.getNanos() * multiplier;
-        int additionalUnits = fullyFledgedNanos / NANOS_IN_UNIT;
-        int nanos = fullyFledgedNanos % NANOS_IN_UNIT;
-        long units = money.getUnits() * multiplier + additionalUnits;
+        var fullyFledgedNanos = money.getNanos() * multiplier;
+        var additionalUnits = fullyFledgedNanos / NANOS_IN_UNIT;
+        var nanos = fullyFledgedNanos % NANOS_IN_UNIT;
+        var units = money.getUnits() * multiplier + additionalUnits;
         return Money
                 .newBuilder()
                 .setUnits(units)

--- a/model/src/main/java/io/spine/examples/shareaware/share/SharesReader.java
+++ b/model/src/main/java/io/spine/examples/shareaware/share/SharesReader.java
@@ -28,7 +28,6 @@ package io.spine.examples.shareaware.share;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.MapLikeType;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.spine.examples.shareaware.ShareId;
 import io.spine.money.Currency;
@@ -73,9 +72,9 @@ public final class SharesReader {
      */
     public static Set<Share> read(File file) {
         checkNotNull(file);
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        MapLikeType mapType = mapper.getTypeFactory()
-                                    .constructMapLikeType(Map.class, String.class, String.class);
+        var mapper = new ObjectMapper(new YAMLFactory());
+        var mapType = mapper.getTypeFactory()
+                            .constructMapLikeType(Map.class, String.class, String.class);
         JavaType listType = mapper.getTypeFactory()
                                   .constructCollectionType(List.class, mapType);
         try {
@@ -89,8 +88,8 @@ public final class SharesReader {
     }
 
     private static Share toShare(Map<String, String> shareData) {
-        ShareId id = ShareId.of(shareData.get("id"));
-        Money price = priceFrom(shareData.get("priceUnits"), shareData.get("priceNanos"));
+        var id = ShareId.of(shareData.get("id"));
+        var price = priceFrom(shareData.get("priceUnits"), shareData.get("priceNanos"));
         return Share
                 .newBuilder()
                 .setId(id)

--- a/model/src/main/java/io/spine/examples/shareaware/share/SharesReader.java
+++ b/model/src/main/java/io/spine/examples/shareaware/share/SharesReader.java
@@ -73,10 +73,12 @@ public final class SharesReader {
     public static Set<Share> read(File file) {
         checkNotNull(file);
         var mapper = new ObjectMapper(new YAMLFactory());
-        var mapType = mapper.getTypeFactory()
-                            .constructMapLikeType(Map.class, String.class, String.class);
-        JavaType listType = mapper.getTypeFactory()
-                                  .constructCollectionType(List.class, mapType);
+        var mapType = mapper
+                .getTypeFactory()
+                .constructMapLikeType(Map.class, String.class, String.class);
+        JavaType listType = mapper
+                .getTypeFactory()
+                .constructCollectionType(List.class, mapType);
         try {
             List<Map<String, String>> sharesData = mapper.readValue(file, listType);
             return sharesData.stream()

--- a/model/src/test/java/io/spine/examples/shareaware/MoneyCalculatorAbstractTest.java
+++ b/model/src/test/java/io/spine/examples/shareaware/MoneyCalculatorAbstractTest.java
@@ -36,8 +36,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.function.BiFunction;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.spine.examples.shareaware.given.GivenMoney.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static io.spine.examples.shareaware.given.GivenMoney.moneyOf;
+import static io.spine.examples.shareaware.given.GivenMoney.usd;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * The abstract base designed for {@link MoneyCalculator} testing.
@@ -90,14 +91,14 @@ abstract class MoneyCalculatorAbstractTest extends UtilityClassTest<MoneyCalcula
 
     private static void testMathCalculation(Money first, Money second, Money expected,
                                             BiFunction<Money, Money, Money> operation) {
-        Money actual = operation.apply(first, second);
+        var actual = operation.apply(first, second);
 
         assertThat(actual).isEqualTo(expected);
     }
 
     private static void testMathCalculation(Money money, int multiplier, Money expected,
                                             BiFunction<Money, Integer, Money> operation) {
-        Money actual = operation.apply(money, multiplier);
+        var actual = operation.apply(money, multiplier);
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -110,33 +111,32 @@ abstract class MoneyCalculatorAbstractTest extends UtilityClassTest<MoneyCalcula
     }
 
     private static <R> void testDifferentCurrencies(BiFunction<Money, Money, R> operation) {
-        Money first = moneyOf(20, Currency.UAH);
-        Money second = moneyOf(30, Currency.USD);
+        var first = moneyOf(20, Currency.UAH);
+        var second = moneyOf(30, Currency.USD);
 
-        IllegalStateException exception =
-                assertThrows(IllegalStateException.class,
-                                        () -> operation.apply(first, second));
+        var exception = assertThrows(IllegalStateException.class,
+                                     () -> operation.apply(first, second));
         assertThat(exception.getMessage())
                 .isEqualTo("Cannot calculate two `Money` objects with different currencies.");
     }
 
     private static <R> void testNegativeUnits(BiFunction<Money, Money, R> operation) {
-        Money positiveUnits = usd(20);
-        Money negativeUnits = usd(-50);
+        var positiveUnits = usd(20);
+        var negativeUnits = usd(-50);
 
         assertThrows(IllegalStateException.class,
-                                () -> operation.apply(positiveUnits, negativeUnits));
+                     () -> operation.apply(positiveUnits, negativeUnits));
         assertThrows(IllegalStateException.class,
-                                () -> operation.apply(negativeUnits, positiveUnits));
+                     () -> operation.apply(negativeUnits, positiveUnits));
     }
 
     private static <R> void testNanosOutOfBounds(BiFunction<Money, Money, R> operation) {
-        Money positiveUnits = usd(0, 120);
-        Money negativeUnits = usd(0, -10);
+        var positiveUnits = usd(0, 120);
+        var negativeUnits = usd(0, -10);
 
         assertThrows(IllegalArgumentException.class,
-                                () -> operation.apply(positiveUnits, negativeUnits));
+                     () -> operation.apply(positiveUnits, negativeUnits));
         assertThrows(IllegalArgumentException.class,
-                                () -> operation.apply(negativeUnits, positiveUnits));
+                     () -> operation.apply(negativeUnits, positiveUnits));
     }
 }

--- a/model/src/test/java/io/spine/examples/shareaware/MoneyCalculatorTest.java
+++ b/model/src/test/java/io/spine/examples/shareaware/MoneyCalculatorTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.examples.shareaware;
 
-import io.spine.money.Money;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,9 +34,9 @@ import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.stream.Stream;
 
-import static io.spine.examples.shareaware.given.GivenMoney.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.params.provider.Arguments.*;
+import static io.spine.examples.shareaware.given.GivenMoney.usd;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @DisplayName("`MoneyCalculator` should")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -89,8 +88,8 @@ final class MoneyCalculatorTest extends MoneyCalculatorAbstractTest {
     @Test
     @DisplayName("validate arguments when calculating the difference")
     void validateSubtract() {
-        Money smaller = usd(20, 20);
-        Money greater = usd(40, 20);
+        var smaller = usd(20, 20);
+        var greater = usd(40, 20);
 
         testValidation(MoneyCalculator::subtract);
         assertThrows(IllegalStateException.class,
@@ -110,7 +109,7 @@ final class MoneyCalculatorTest extends MoneyCalculatorAbstractTest {
         @Test
         @DisplayName("for negative `Money` value")
         void performNegativeUnits() {
-            Money negativeUnits = usd(-20);
+            var negativeUnits = usd(-20);
             assertThrows(IllegalStateException.class,
                          () -> MoneyCalculator.multiply(negativeUnits, 2));
         }
@@ -118,7 +117,7 @@ final class MoneyCalculatorTest extends MoneyCalculatorAbstractTest {
         @Test
         @DisplayName("for out of bounds `Money.nanos` value")
         void performNanosOutOfBounds() {
-            Money nanosOutOfBound = usd(0, -120);
+            var nanosOutOfBound = usd(0, -120);
             assertThrows(IllegalArgumentException.class,
                          () -> MoneyCalculator.multiply(nanosOutOfBound, 2));
         }
@@ -126,7 +125,7 @@ final class MoneyCalculatorTest extends MoneyCalculatorAbstractTest {
         @Test
         @DisplayName("for negative multiplier value")
         void performNegativeMultiplier() {
-            Money money = usd(20);
+            var money = usd(20);
             assertThrows(IllegalArgumentException.class,
                          () -> MoneyCalculator.multiply(money, -2));
         }

--- a/model/src/test/java/io/spine/examples/shareaware/share/SharesReaderTest.java
+++ b/model/src/test/java/io/spine/examples/shareaware/share/SharesReaderTest.java
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.net.URL;
-import java.util.Set;
 
 import static io.spine.examples.shareaware.share.SharesReaderTestEnv.expectedSharesFromFile;
 import static java.lang.Thread.currentThread;
@@ -50,11 +48,11 @@ final class SharesReaderTest extends UtilityClassTest<SharesReader> {
     @Test
     @DisplayName("read shares from file")
     void readShares() {
-        ClassLoader classLoader = currentThread().getContextClassLoader();
-        URL urlToFile = requireNonNull(classLoader.getResource("testing-shares.yml"));
-        File file = new File(urlToFile.getFile());
-        Set<Share> shares = SharesReader.read(file);
-        Set<Share> expected = expectedSharesFromFile();
+        var classLoader = currentThread().getContextClassLoader();
+        var urlToFile = requireNonNull(classLoader.getResource("testing-shares.yml"));
+        var file = new File(urlToFile.getFile());
+        var shares = SharesReader.read(file);
+        var expected = expectedSharesFromFile();
 
         Truth.assertThat(shares)
              .isEqualTo(expected);
@@ -63,7 +61,7 @@ final class SharesReaderTest extends UtilityClassTest<SharesReader> {
     @Test
     @DisplayName("throw `IllegalArgumentException` when the provided file is invalid")
     void throwException() {
-        File file = new File("notExistingFile.yml");
+        var file = new File("notExistingFile.yml");
         assertThrows(IllegalArgumentException.class, () -> SharesReader.read(file));
     }
 }

--- a/model/src/test/java/io/spine/examples/shareaware/share/SharesReaderTest.java
+++ b/model/src/test/java/io/spine/examples/shareaware/share/SharesReaderTest.java
@@ -61,7 +61,7 @@ final class SharesReaderTest extends UtilityClassTest<SharesReader> {
     @Test
     @DisplayName("throw `IllegalArgumentException` when the provided file is invalid")
     void throwException() {
-        var file = new File("notExistingFile.yml");
+        var file = new File("nonexistentFile.yml");
         assertThrows(IllegalArgumentException.class, () -> SharesReader.read(file));
     }
 }

--- a/model/src/test/java/io/spine/examples/shareaware/share/SharesReaderTest.java
+++ b/model/src/test/java/io/spine/examples/shareaware/share/SharesReaderTest.java
@@ -26,13 +26,13 @@
 
 package io.spine.examples.shareaware.share;
 
-import com.google.common.truth.Truth;
 import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
+import static com.google.common.truth.Truth.assertThat;
 import static io.spine.examples.shareaware.share.SharesReaderTestEnv.expectedSharesFromFile;
 import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
@@ -54,8 +54,7 @@ final class SharesReaderTest extends UtilityClassTest<SharesReader> {
         var shares = SharesReader.read(file);
         var expected = expectedSharesFromFile();
 
-        Truth.assertThat(shares)
-             .isEqualTo(expected);
+        assertThat(shares).isEqualTo(expected);
     }
 
     @Test

--- a/model/src/test/java/io/spine/examples/shareaware/share/SharesReaderTestEnv.java
+++ b/model/src/test/java/io/spine/examples/shareaware/share/SharesReaderTestEnv.java
@@ -31,7 +31,7 @@ import io.spine.examples.shareaware.ShareId;
 
 import java.util.Set;
 
-import static io.spine.examples.shareaware.given.GivenMoney.*;
+import static io.spine.examples.shareaware.given.GivenMoney.usd;
 
 final class SharesReaderTestEnv {
 
@@ -42,14 +42,14 @@ final class SharesReaderTestEnv {
     }
 
     static Set<Share> expectedSharesFromFile() {
-        Share goodShare = Share
+        var goodShare = Share
                 .newBuilder()
                 .setId(ShareId.of("9c6456b3-eccb-48db-90d3-af2595f77f59"))
                 .setPrice(usd(100, 50))
                 .setCompanyName("AwesomeCompany")
                 .setCompanyLogo("https://awesome.site.org/images/logo.svg")
                 .vBuild();
-        Share awesomeShare = Share
+        var awesomeShare = Share
                 .newBuilder()
                 .setId(ShareId.of("4b8326b3-eccb-48db-45d3-af2595d55f59"))
                 .setPrice(usd(100, 50))

--- a/server/src/main/java/io/spine/examples/shareaware/server/investment/InvestmentAggregate.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/investment/InvestmentAggregate.java
@@ -49,7 +49,7 @@ public final class InvestmentAggregate
 
     @Assign
     SharesAdded on(AddShares c) {
-        int newAvailableShares = state().getSharesAvailable() + c.getQuantity();
+        var newAvailableShares = state().getSharesAvailable() + c.getQuantity();
         return SharesAdded
                 .newBuilder()
                 .setInvestment(c.getInvestment())
@@ -85,9 +85,9 @@ public final class InvestmentAggregate
 
     @Apply
     private void event(SharesReserved e) {
-        int newAvailableShares = state().getSharesAvailable() - e.getQuantity();
-        String saleId = e.getProcess()
-                         .getUuid();
+        var newAvailableShares = state().getSharesAvailable() - e.getQuantity();
+        var saleId = e.getProcess()
+                      .getUuid();
         builder()
                 .setSharesAvailable(newAvailableShares)
                 .putSharesReserved(saleId, e.getQuantity());
@@ -120,10 +120,10 @@ public final class InvestmentAggregate
 
     @Apply
     private void event(SharesReservationCanceled e) {
-        String saleId = e.getProcess()
-                         .getUuid();
-        int reservedSharesAmount = state().getSharesReservedOrThrow(saleId);
-        int restoredAvailableShares = state().getSharesAvailable() + reservedSharesAmount;
+        var saleId = e.getProcess()
+                      .getUuid();
+        var reservedSharesAmount = state().getSharesReservedOrThrow(saleId);
+        var restoredAvailableShares = state().getSharesAvailable() + reservedSharesAmount;
         builder()
                 .setSharesAvailable(restoredAvailableShares)
                 .removeSharesReserved(saleId);

--- a/server/src/main/java/io/spine/examples/shareaware/server/investment/InvestmentViewProjection.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/investment/InvestmentViewProjection.java
@@ -43,8 +43,8 @@ final class InvestmentViewProjection
 
     @Subscribe
     void on(SharesPurchased e) {
-        UserId owner = e.getPurchaser();
-        ShareId share = e.getShare();
+        var owner = e.getPurchaser();
+        var share = e.getShare();
         builder()
                 .setId(investmentId(owner, share))
                 .setSharesAvailable(e.getSharesAvailable());
@@ -52,8 +52,8 @@ final class InvestmentViewProjection
 
     @Subscribe
     void on(SharesSold e) {
-        UserId owner = e.getSeller();
-        ShareId share = e.getShare();
+        var owner = e.getSeller();
+        var share = e.getShare();
         builder()
                 .setId(investmentId(owner, share))
                 .setSharesAvailable(e.getSharesAvailable());

--- a/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesSaleProcess.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/investment/SharesSaleProcess.java
@@ -65,8 +65,8 @@ final class SharesSaleProcess
     @Command
     ReserveShares on(SellShares c) {
         initState(c);
-        UserId user = c.getSeller();
-        ShareId share = c.getShare();
+        var user = c.getSeller();
+        var share = c.getShare();
         return ReserveShares
                 .newBuilder()
                 .setProcess(c.getSaleProcess())
@@ -159,8 +159,8 @@ final class SharesSaleProcess
      */
     @Command
     CompleteSharesReservation on(BalanceRecharged e) {
-        SaleId process = e.getOperation()
-                          .getSale();
+        var process = e.getOperation()
+                       .getSale();
         return CompleteSharesReservation
                 .newBuilder()
                 .setInvestment(investmentId())

--- a/server/src/main/java/io/spine/examples/shareaware/server/market/MarketData.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/market/MarketData.java
@@ -32,9 +32,7 @@ import io.spine.examples.shareaware.share.SharesReader;
 import io.spine.money.Money;
 
 import java.io.File;
-import java.net.URL;
 import java.security.SecureRandom;
-import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -59,9 +57,9 @@ final class MarketData {
     }
 
     static {
-        ClassLoader classLoader = currentThread().getContextClassLoader();
-        URL urlToFile = requireNonNull(classLoader.getResource("shares.yml"));
-        File file = new File(urlToFile.getFile());
+        var classLoader = currentThread().getContextClassLoader();
+        var urlToFile = requireNonNull(classLoader.getResource("shares.yml"));
+        var file = new File(urlToFile.getFile());
         shares = SharesReader.read(file);
     }
 
@@ -69,7 +67,7 @@ final class MarketData {
      * Returns the list of up-to-date shares that are available on the market.
      */
     static ImmutableList<Share> actualShares() {
-        List<Share> actualShares = shares.stream()
+        var actualShares = shares.stream()
                 .map(MarketData::actualize)
                 .collect(Collectors.toList());
         return ImmutableList.copyOf(actualShares);
@@ -81,7 +79,7 @@ final class MarketData {
      * <p>Simulates the share price updates on the market.
      */
     private static Share actualize(Share share) {
-        Money updatedPrice = updatePrice(share.getPrice());
+        var updatedPrice = updatePrice(share.getPrice());
         return share
                 .toBuilder()
                 .setPrice(updatedPrice)
@@ -89,12 +87,12 @@ final class MarketData {
     }
 
     private static Money updatePrice(Money previousPrice) {
-        int nanosInUnit = 100;
+        var nanosInUnit = 100;
         Random random = new SecureRandom();
-        int valueToSumWithUnits = random.nextInt(21) - 10;
-        long updatedUnits = previousPrice.getUnits() + valueToSumWithUnits;
-        int valueToSumWithNanos = random.nextInt(nanosInUnit) - 50;
-        int updatedNanos = previousPrice.getNanos() + valueToSumWithNanos;
+        var valueToSumWithUnits = random.nextInt(21) - 10;
+        var updatedUnits = previousPrice.getUnits() + valueToSumWithUnits;
+        var valueToSumWithNanos = random.nextInt(nanosInUnit) - 50;
+        var updatedNanos = previousPrice.getNanos() + valueToSumWithNanos;
         if (updatedNanos / nanosInUnit >= 1) {
             updatedUnits++;
             updatedNanos -= nanosInUnit;

--- a/server/src/main/java/io/spine/examples/shareaware/server/market/MarketData.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/market/MarketData.java
@@ -67,7 +67,8 @@ final class MarketData {
      * Returns the list of up-to-date shares that are available on the market.
      */
     static ImmutableList<Share> actualShares() {
-        var actualShares = shares.stream()
+        var actualShares = shares
+                .stream()
                 .map(MarketData::actualize)
                 .collect(Collectors.toList());
         return ImmutableList.copyOf(actualShares);

--- a/server/src/main/java/io/spine/examples/shareaware/server/market/MarketDataProvider.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/market/MarketDataProvider.java
@@ -26,9 +26,7 @@
 
 package io.spine.examples.shareaware.server.market;
 
-import com.google.common.collect.ImmutableList;
 import io.spine.core.UserId;
-import io.spine.examples.shareaware.share.Share;
 import io.spine.examples.shareaware.market.event.MarketSharesUpdated;
 import io.spine.server.integration.ThirdPartyContext;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -123,8 +121,8 @@ public final class MarketDataProvider {
     }
 
     private void emitEvent() {
-        ImmutableList<Share> updatedShares = MarketData.actualShares();
-        MarketSharesUpdated event = MarketSharesUpdated
+        var updatedShares = MarketData.actualShares();
+        var event = MarketSharesUpdated
                 .newBuilder()
                 .setMarket(MarketProcess.ID)
                 .addAllShare(updatedShares)

--- a/server/src/main/java/io/spine/examples/shareaware/server/market/MarketProcess.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/market/MarketProcess.java
@@ -38,7 +38,6 @@ import io.spine.examples.shareaware.market.event.SharesObtained;
 import io.spine.examples.shareaware.market.event.SharesSoldOnMarket;
 import io.spine.examples.shareaware.market.rejection.SharesCannotBeObtained;
 import io.spine.examples.shareaware.market.rejection.SharesCannotBeSoldOnMarket;
-import io.spine.money.Money;
 import io.spine.server.command.Assign;
 import io.spine.server.procman.ProcessManager;
 
@@ -95,7 +94,7 @@ public final class MarketProcess
                     .setSaleProcess(c.getSaleProcess())
                     .build();
         }
-        Money sellPrice = multiply(c.getPrice(), c.getQuantity());
+        var sellPrice = multiply(c.getPrice(), c.getQuantity());
         return SharesSoldOnMarket
                 .newBuilder()
                 .setMarket(c.getMarket())

--- a/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletAggregate.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/wallet/WalletAggregate.java
@@ -83,7 +83,7 @@ public final class WalletAggregate extends Aggregate<WalletId, Wallet, Wallet.Bu
 
     @Assign
     BalanceRecharged handle(RechargeBalance c) {
-        Money newBalance = sum(state().getBalance(), c.getMoneyAmount());
+        var newBalance = sum(state().getBalance(), c.getMoneyAmount());
         return BalanceRecharged
                 .newBuilder()
                 .setWallet(c.getWallet())
@@ -117,8 +117,8 @@ public final class WalletAggregate extends Aggregate<WalletId, Wallet, Wallet.Bu
 
     @Apply
     private void event(MoneyReserved e) {
-        Money newBalance = subtract(state().getBalance(), e.getAmount());
-        String operationId = e.operationIdValue();
+        var newBalance = subtract(state().getBalance(), e.getAmount());
+        var operationId = e.operationIdValue();
         builder()
                 .setBalance(newBalance)
                 .putReservedMoney(operationId, e.getAmount());
@@ -136,7 +136,7 @@ public final class WalletAggregate extends Aggregate<WalletId, Wallet, Wallet.Bu
 
     @Apply
     private void event(ReservedMoneyDebited e) {
-        String operationId = e.operationIdValue();
+        var operationId = e.operationIdValue();
         builder().removeReservedMoney(operationId);
     }
 
@@ -151,9 +151,9 @@ public final class WalletAggregate extends Aggregate<WalletId, Wallet, Wallet.Bu
 
     @Apply
     private void event(MoneyReservationCanceled e) {
-        String operationId = e.operationIdValue();
-        Money reservedAmount = state().getReservedMoneyOrThrow(operationId);
-        Money restoredBalance = sum(state().getBalance(), reservedAmount);
+        var operationId = e.operationIdValue();
+        var reservedAmount = state().getReservedMoneyOrThrow(operationId);
+        var restoredBalance = sum(state().getBalance(), reservedAmount);
         builder()
                 .setBalance(restoredBalance)
                 .removeReservedMoney(operationId);

--- a/server/src/main/java/io/spine/examples/shareaware/server/watchlist/UserWatchlistsProjection.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/watchlist/UserWatchlistsProjection.java
@@ -42,7 +42,7 @@ final class UserWatchlistsProjection
 
     @Subscribe
     void on(WatchlistCreated e) {
-        WatchlistView watchlist = WatchlistView
+        var watchlist = WatchlistView
                 .newBuilder()
                 .setId(e.getWatchlist())
                 .setName(e.getName())

--- a/server/src/test/java/io/spine/examples/shareaware/server/e2e/SharePurchaseTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/e2e/SharePurchaseTest.java
@@ -26,18 +26,10 @@
 
 package io.spine.examples.shareaware.server.e2e;
 
-import io.grpc.ManagedChannel;
-import io.spine.examples.shareaware.investment.InvestmentView;
 import io.spine.examples.shareaware.server.e2e.given.E2EUser;
 import io.spine.examples.shareaware.server.e2e.given.WithServer;
-import io.spine.examples.shareaware.share.Share;
-import io.spine.examples.shareaware.wallet.WalletBalance;
-import io.spine.examples.shareaware.wallet.rejection.Rejections.InsufficientFunds;
-import io.spine.server.tuple.EitherOf2;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static io.spine.examples.shareaware.given.GivenMoney.usd;
@@ -61,28 +53,27 @@ final class SharePurchaseTest extends WithServer {
     @Test
     @DisplayName("User should purchase one tesla share and withdraw all the money after this")
     void test() {
-        ManagedChannel channel = openChannel();
-        E2EUser user = new E2EUser(channel);
+        var channel = openChannel();
+        var user = new E2EUser(channel);
 
-        List<Share> shares = user.looksAtAvailableShares();
-        Share tesla = pickTesla(shares);
+        var shares = user.looksAtAvailableShares();
+        var tesla = pickTesla(shares);
 
-        EitherOf2<WalletBalance, InsufficientFunds> failedPurchase = user.purchase(tesla, 1);
-        InsufficientFunds insufficientFunds = failedPurchase.getB();
+        var failedPurchase = user.purchase(tesla, 1);
+        var insufficientFunds = failedPurchase.getB();
         assertThat(insufficientFunds.getAmount()).isEqualTo(tesla.getPrice());
 
-        WalletBalance balanceAfterReplenishment = user.replenishesWalletFor(usd(500));
+        var balanceAfterReplenishment = user.replenishesWalletFor(usd(500));
 
-        EitherOf2<WalletBalance, InsufficientFunds> successfulPurchase = user.purchase(tesla, 1);
-        WalletBalance balanceAfterPurchase = successfulPurchase.getA();
-        InvestmentView investmentInTesla = user.looksAtInvestment();
-        WalletBalance expectedBalance =
-                balanceAfterPurchase(tesla.getPrice(), balanceAfterReplenishment);
-        InvestmentView expectedInvestmentInTesla = investmentAfterPurchase(tesla, user.id());
+        var successfulPurchase = user.purchase(tesla, 1);
+        var balanceAfterPurchase = successfulPurchase.getA();
+        var investmentInTesla = user.looksAtInvestment();
+        var expectedBalance = balanceAfterPurchase(tesla.getPrice(), balanceAfterReplenishment);
+        var expectedInvestmentInTesla = investmentAfterPurchase(tesla, user.id());
         assertThat(balanceAfterPurchase).isEqualTo(expectedBalance);
         assertThat(investmentInTesla).isEqualTo(expectedInvestmentInTesla);
 
-        WalletBalance walletAfterWithdrawal = user.withdrawsAllMoney(balanceAfterPurchase);
+        var walletAfterWithdrawal = user.withdrawsAllMoney(balanceAfterPurchase);
         assertThat(walletAfterWithdrawal).isEqualTo(zeroWalletBalance(user.walletId()));
     }
 }

--- a/server/src/test/java/io/spine/examples/shareaware/server/e2e/given/SharePurchaseTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/e2e/given/SharePurchaseTestEnv.java
@@ -36,7 +36,6 @@ import io.spine.examples.shareaware.wallet.WalletBalance;
 import io.spine.money.Money;
 
 import java.util.Collection;
-import java.util.Optional;
 
 import static io.spine.examples.shareaware.MoneyCalculator.subtract;
 import static io.spine.examples.shareaware.given.GivenMoney.zero;
@@ -68,7 +67,7 @@ public final class SharePurchaseTestEnv {
 
     public static WalletBalance balanceAfterPurchase(Money sharePrice,
                                                      WalletBalance balance) {
-        Money reducedBalance = subtract(balance.getBalance(), sharePrice);
+        var reducedBalance = subtract(balance.getBalance(), sharePrice);
         return balance
                 .toBuilder()
                 .setBalance(reducedBalance)
@@ -76,7 +75,7 @@ public final class SharePurchaseTestEnv {
     }
 
     public static InvestmentView investmentAfterPurchase(Share tesla, UserId user) {
-        InvestmentId id = investmentId(user, tesla.getId());
+        var id = investmentId(user, tesla.getId());
         return InvestmentView
                 .newBuilder()
                 .setId(id)
@@ -93,7 +92,7 @@ public final class SharePurchaseTestEnv {
     }
 
     public static Share pickTesla(Collection<Share> shares) {
-        Optional<Share> tesla = shares
+        var tesla = shares
                 .stream()
                 .filter(share -> share.getCompanyName()
                                        .toLowerCase()

--- a/server/src/test/java/io/spine/examples/shareaware/server/e2e/given/WithServer.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/e2e/given/WithServer.java
@@ -96,7 +96,7 @@ public abstract class WithServer {
      * Opens a channel.
      */
     protected ManagedChannel openChannel() {
-        ManagedChannel channel = forAddress(ADDRESS, PORT)
+        var channel = forAddress(ADDRESS, PORT)
                 .usePlaintext()
                 .build();
         channels.add(channel);

--- a/server/src/test/java/io/spine/examples/shareaware/server/given/GivenWallet.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/given/GivenWallet.java
@@ -73,8 +73,8 @@ public final class GivenWallet {
      * @return the ID of created {@code Wallet}.
      */
     public static WalletId setUpWallet(BlackBoxContext context) {
-        WalletId wallet = givenId();
-        CreateWallet command = createWallet(wallet);
+        var wallet = givenId();
+        var command = createWallet(wallet);
         context.receivesCommand(command);
         return wallet;
     }

--- a/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
@@ -9,7 +9,6 @@ import io.spine.examples.shareaware.given.GivenMoney;
 import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyFromUser;
 import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyToUser;
 import io.spine.examples.shareaware.paymentgateway.event.MoneyTransferredToUser;
-import io.spine.examples.shareaware.paymentgateway.rejection.Rejections.MoneyCannotBeTransferredFromUser;
 import io.spine.examples.shareaware.server.paymentgateway.PaymentGatewayProcess;
 import io.spine.examples.shareaware.wallet.Iban;
 import io.spine.examples.shareaware.wallet.Wallet;
@@ -17,7 +16,6 @@ import io.spine.examples.shareaware.wallet.WalletBalance;
 import io.spine.examples.shareaware.wallet.WalletReplenishment;
 import io.spine.examples.shareaware.wallet.WalletWithdrawal;
 import io.spine.examples.shareaware.wallet.command.CancelMoneyReservation;
-import io.spine.examples.shareaware.wallet.command.CreateWallet;
 import io.spine.examples.shareaware.wallet.command.DebitReservedMoney;
 import io.spine.examples.shareaware.wallet.command.RechargeBalance;
 import io.spine.examples.shareaware.wallet.command.ReplenishWallet;
@@ -35,7 +33,6 @@ import io.spine.examples.shareaware.wallet.event.WalletReplenished;
 import io.spine.examples.shareaware.wallet.rejection.Rejections.InsufficientFunds;
 import io.spine.money.Currency;
 import io.spine.money.Money;
-import io.spine.testing.core.given.GivenUserId;
 import io.spine.testing.server.blackbox.BlackBoxContext;
 
 import static io.spine.examples.shareaware.MoneyCalculator.subtract;
@@ -144,14 +141,6 @@ public final class WalletTestEnv {
                 .setReplenishment(command.getReplenishment())
                 .setWallet(command.getWallet())
                 .setMoneyAmount(command.getMoneyAmount())
-                .vBuild();
-    }
-
-    public static MoneyCannotBeTransferredFromUser
-    moneyCannotBeTransferredFromUserBy(ReplenishmentId replenishmentProcess) {
-        return MoneyCannotBeTransferredFromUser
-                .newBuilder()
-                .setReplenishment(replenishmentProcess)
                 .vBuild();
     }
 

--- a/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/given/WalletTestEnv.java
@@ -1,17 +1,16 @@
 package io.spine.examples.shareaware.server.given;
 
-import io.spine.examples.shareaware.WithdrawalOperationId;
 import io.spine.examples.shareaware.ReplenishmentId;
 import io.spine.examples.shareaware.ReplenishmentOperationId;
 import io.spine.examples.shareaware.WalletId;
 import io.spine.examples.shareaware.WithdrawalId;
+import io.spine.examples.shareaware.WithdrawalOperationId;
 import io.spine.examples.shareaware.given.GivenMoney;
 import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyFromUser;
 import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyToUser;
 import io.spine.examples.shareaware.paymentgateway.event.MoneyTransferredToUser;
 import io.spine.examples.shareaware.paymentgateway.rejection.Rejections.MoneyCannotBeTransferredFromUser;
 import io.spine.examples.shareaware.server.paymentgateway.PaymentGatewayProcess;
-import io.spine.examples.shareaware.MoneyCalculator;
 import io.spine.examples.shareaware.wallet.Iban;
 import io.spine.examples.shareaware.wallet.Wallet;
 import io.spine.examples.shareaware.wallet.WalletBalance;
@@ -39,9 +38,9 @@ import io.spine.money.Money;
 import io.spine.testing.core.given.GivenUserId;
 import io.spine.testing.server.blackbox.BlackBoxContext;
 
-import static io.spine.examples.shareaware.given.GivenMoney.moneyOf;
 import static io.spine.examples.shareaware.MoneyCalculator.subtract;
 import static io.spine.examples.shareaware.MoneyCalculator.sum;
+import static io.spine.examples.shareaware.given.GivenMoney.moneyOf;
 
 public final class WalletTestEnv {
 
@@ -74,7 +73,7 @@ public final class WalletTestEnv {
      * Generates {@code ReplenishWallet} command.
      */
     private static ReplenishWallet replenish(WalletId wallet, Money amount) {
-        ReplenishmentId replenishment = ReplenishmentId.generate();
+        var replenishment = ReplenishmentId.generate();
         return ReplenishWallet
                 .newBuilder()
                 .setWallet(wallet)
@@ -88,7 +87,7 @@ public final class WalletTestEnv {
      * Generates {@code ReplenishWallet} command on 500 USD for the wallet.
      */
     public static ReplenishWallet replenish(WalletId wallet) {
-        Money replenishmentAmount = moneyOf(500, Currency.USD);
+        var replenishmentAmount = moneyOf(500, Currency.USD);
         return replenish(wallet, replenishmentAmount);
     }
 
@@ -98,8 +97,8 @@ public final class WalletTestEnv {
      * @return the ID of created {@code Wallet}.
      */
     public static WalletId setUpWallet(BlackBoxContext context) {
-        WalletId wallet = givenId();
-        CreateWallet command = createWallet(wallet);
+        var wallet = givenId();
+        var command = createWallet(wallet);
         context.receivesCommand(command);
         return wallet;
     }
@@ -107,9 +106,8 @@ public final class WalletTestEnv {
     public static Wallet walletReplenishedBy(ReplenishWallet firstReplenishment,
                                              ReplenishWallet secondReplenishment,
                                              WalletId wallet) {
-        Money expectedBalance =
-                MoneyCalculator.sum(firstReplenishment.getMoneyAmount(),
-                                    secondReplenishment.getMoneyAmount());
+        var expectedBalance = sum(firstReplenishment.getMoneyAmount(),
+                                  secondReplenishment.getMoneyAmount());
         return Wallet
                 .newBuilder()
                 .setId(wallet)
@@ -129,9 +127,9 @@ public final class WalletTestEnv {
     public static WalletBalance walletBalanceAfterReplenishment(ReplenishWallet firstReplenishment,
                                                                 ReplenishWallet secondReplenishment,
                                                                 WalletId wallet) {
-        Wallet replenishedWallet = walletReplenishedBy(firstReplenishment,
-                                                 secondReplenishment,
-                                                 wallet);
+        var replenishedWallet = walletReplenishedBy(firstReplenishment,
+                                                    secondReplenishment,
+                                                    wallet);
         return WalletBalance
                 .newBuilder()
                 .setId(replenishedWallet.getId())
@@ -195,8 +193,8 @@ public final class WalletTestEnv {
     }
 
     public static Wallet setUpReplenishedWallet(BlackBoxContext context) {
-        WalletId wallet = setUpWallet(context);
-        ReplenishWallet command = replenish(wallet);
+        var wallet = setUpWallet(context);
+        var command = replenish(wallet);
         context.receivesCommand(command);
         return Wallet
                 .newBuilder()
@@ -224,7 +222,7 @@ public final class WalletTestEnv {
 
     public static ReservedMoneyDebited reservedMoneyDebitedFrom(Wallet wallet,
                                                                 WithdrawMoney command) {
-        Money reducedBalance = subtract(wallet.getBalance(), command.getAmount());
+        var reducedBalance = subtract(wallet.getBalance(), command.getAmount());
         return ReservedMoneyDebited
                 .newBuilder()
                 .setOperation(operationId(command.getWithdrawalProcess()))
@@ -298,7 +296,7 @@ public final class WalletTestEnv {
     }
 
     public static MoneyWithdrawn moneyWithdrawnBy(WithdrawMoney command, Wallet wallet) {
-        Money reducedBalance = subtract(wallet.getBalance(), command.getAmount());
+        var reducedBalance = subtract(wallet.getBalance(), command.getAmount());
         return MoneyWithdrawn
                 .newBuilder()
                 .setWithdrawalProcess(command.getWithdrawalProcess())
@@ -334,10 +332,8 @@ public final class WalletTestEnv {
     public static Wallet walletWhichWasWithdrawnBy(WithdrawMoney firstWithdraw,
                                                    WithdrawMoney secondWithdraw,
                                                    Wallet wallet) {
-        Money withdrawalAmount =
-                sum(firstWithdraw.getAmount(), secondWithdraw.getAmount());
-        Money expectedBalance =
-                subtract(wallet.getBalance(), withdrawalAmount);
+        var withdrawalAmount = sum(firstWithdraw.getAmount(), secondWithdraw.getAmount());
+        var expectedBalance = subtract(wallet.getBalance(), withdrawalAmount);
         return Wallet
                 .newBuilder()
                 .setId(wallet.getId())
@@ -348,10 +344,8 @@ public final class WalletTestEnv {
     public static WalletBalance walletBalanceReducedBy(WithdrawMoney firstWithdraw,
                                                        WithdrawMoney secondWithdraw,
                                                        Wallet wallet) {
-        Money withdrawalAmount =
-                sum(firstWithdraw.getAmount(), secondWithdraw.getAmount());
-        Money expectedBalance =
-                subtract(wallet.getBalance(), withdrawalAmount);
+        var withdrawalAmount = sum(firstWithdraw.getAmount(), secondWithdraw.getAmount());
+        var expectedBalance = subtract(wallet.getBalance(), withdrawalAmount);
         return WalletBalance
                 .newBuilder()
                 .setId(wallet.getId())

--- a/server/src/test/java/io/spine/examples/shareaware/server/given/WatchlistTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/given/WatchlistTestEnv.java
@@ -55,7 +55,7 @@ public final class WatchlistTestEnv {
     }
 
     public static Watchlist setUpWatchlist(BlackBoxContext context) {
-        CreateWatchlist command = createWatchlist();
+        var command = createWatchlist();
         context.receivesCommand(command);
         return Watchlist
                 .newBuilder()

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesPurchaseTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesPurchaseTest.java
@@ -26,39 +26,23 @@
 
 package io.spine.examples.shareaware.server.investment;
 
-import io.spine.core.UserId;
-import io.spine.examples.shareaware.InvestmentId;
 import io.spine.examples.shareaware.ShareId;
-import io.spine.examples.shareaware.WalletId;
-import io.spine.examples.shareaware.investment.InvestmentView;
-import io.spine.examples.shareaware.investment.Investment;
-import io.spine.examples.shareaware.investment.SharesPurchase;
 import io.spine.examples.shareaware.investment.command.AddShares;
-import io.spine.examples.shareaware.investment.command.PurchaseShares;
-import io.spine.examples.shareaware.investment.event.SharesAdded;
-import io.spine.examples.shareaware.investment.event.SharesPurchaseFailed;
-import io.spine.examples.shareaware.investment.event.SharesPurchased;
 import io.spine.examples.shareaware.market.command.ObtainShares;
 import io.spine.examples.shareaware.server.FreshContextTest;
 import io.spine.examples.shareaware.server.investment.given.InvestmentTestContext;
 import io.spine.examples.shareaware.server.investment.given.RejectingMarket;
-import io.spine.examples.shareaware.wallet.Wallet;
-import io.spine.examples.shareaware.wallet.WalletBalance;
 import io.spine.examples.shareaware.wallet.command.CancelMoneyReservation;
 import io.spine.examples.shareaware.wallet.command.DebitReservedMoney;
 import io.spine.examples.shareaware.wallet.command.ReserveMoney;
-import io.spine.examples.shareaware.wallet.event.MoneyReservationCanceled;
-import io.spine.examples.shareaware.wallet.event.MoneyReserved;
-import io.spine.examples.shareaware.wallet.event.ReservedMoneyDebited;
-import io.spine.examples.shareaware.wallet.rejection.Rejections.InsufficientFunds;
 import io.spine.server.BoundedContextBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.examples.shareaware.server.investment.given.InvestmentTestEnv.*;
 import static io.spine.examples.shareaware.server.given.WalletTestEnv.setUpReplenishedWallet;
 import static io.spine.examples.shareaware.server.given.WalletTestEnv.setUpWallet;
+import static io.spine.examples.shareaware.server.investment.given.InvestmentTestEnv.*;
 
 @DisplayName("`SharesPurchase` should")
 public final class SharesPurchaseTest extends FreshContextTest {
@@ -75,12 +59,12 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("for the purchase price amount")
         void walletState() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            UserId user = wallet.getId()
-                                .getOwner();
-            PurchaseShares firstPurchase = purchaseSharesFor(user);
-            PurchaseShares secondPurchase = purchaseSharesFor(user);
-            Wallet walletAfterPurchase =
+            var wallet = setUpReplenishedWallet(context());
+            var user = wallet.getId()
+                             .getOwner();
+            var firstPurchase = purchaseSharesFor(user);
+            var secondPurchase = purchaseSharesFor(user);
+            var walletAfterPurchase =
                     walletAfter(firstPurchase, secondPurchase, wallet);
             context().receivesCommands(firstPurchase, secondPurchase);
 
@@ -90,10 +74,10 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("emitting the `MoneyReserved` event")
         void moneyReserved() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            PurchaseShares command = purchaseSharesFor(wallet.getId()
-                                                             .getOwner());
-            MoneyReserved expected = moneyReservedBy(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = purchaseSharesFor(wallet.getId()
+                                                  .getOwner());
+            var expected = moneyReservedBy(command);
             context().receivesCommand(command);
 
             context().assertEvent(expected);
@@ -102,10 +86,10 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("emitting the `ReservedMoneyDebited` event")
         void reservedMoneyDebited() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            PurchaseShares command = purchaseSharesFor(wallet.getId()
-                                                             .getOwner());
-            ReservedMoneyDebited expected = reservedMoneyDebitedBy(command, wallet);
+            var wallet = setUpReplenishedWallet(context());
+            var command = purchaseSharesFor(wallet.getId()
+                                                  .getOwner());
+            var expected = reservedMoneyDebitedBy(command, wallet);
             context().receivesCommand(command);
 
             context().assertEvent(expected);
@@ -114,9 +98,9 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("emitting the `InsufficientFunds` rejection")
         void insufficientFunds() {
-            WalletId walletId = setUpWallet(context());
-            PurchaseShares command = purchaseSharesFor(walletId.getOwner());
-            InsufficientFunds expected = insufficientFundsIn(walletId, command);
+            var walletId = setUpWallet(context());
+            var command = purchaseSharesFor(walletId.getOwner());
+            var expected = insufficientFundsIn(walletId, command);
             context().receivesCommand(command);
 
             context().assertEvent(expected);
@@ -125,10 +109,10 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("emitting the `MoneyReservationCanceled` event")
         void reservationCanceled() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            PurchaseShares command = purchaseSharesFor(wallet.getId()
-                                                             .getOwner());
-            MoneyReservationCanceled expected = moneyReservationCanceledAfter(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = purchaseSharesFor(wallet.getId()
+                                                  .getOwner());
+            var expected = moneyReservationCanceledAfter(command);
             RejectingMarket.switchToRejectionMode();
             context().receivesCommand(command);
 
@@ -144,14 +128,14 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("by adding shares to it")
         void investmentState() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            UserId user = wallet.getId()
-                                .getOwner();
-            ShareId share = ShareId.generate();
-            PurchaseShares firstPurchase = purchaseSharesFor(user, share);
-            PurchaseShares secondPurchase = purchaseSharesFor(user, share);
-            Investment expected = investmentAfter(firstPurchase, secondPurchase);
-            InvestmentId investmentId = investmentId(user, share);
+            var wallet = setUpReplenishedWallet(context());
+            var user = wallet.getId()
+                             .getOwner();
+            var share = ShareId.generate();
+            var firstPurchase = purchaseSharesFor(user, share);
+            var secondPurchase = purchaseSharesFor(user, share);
+            var expected = investmentAfter(firstPurchase, secondPurchase);
+            var investmentId = investmentId(user, share);
             context().receivesCommands(firstPurchase, secondPurchase);
 
             context().assertState(investmentId, expected);
@@ -159,11 +143,11 @@ public final class SharesPurchaseTest extends FreshContextTest {
 
         @Test
         void sharesAdded() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            UserId user = wallet.getId()
-                                .getOwner();
-            PurchaseShares command = purchaseSharesFor(user);
-            SharesAdded expected = sharesAddedBy(command);
+            var wallet = setUpReplenishedWallet(context());
+            var user = wallet.getId()
+                             .getOwner();
+            var command = purchaseSharesFor(user);
+            var expected = sharesAddedBy(command);
             context().receivesCommand(command);
 
             context().assertEvent(expected);
@@ -177,10 +161,10 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("with state")
         void state() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            PurchaseShares command = purchaseSharesFor(wallet.getId()
-                                                             .getOwner());
-            SharesPurchase expected = sharesPurchaseStateWhen(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = purchaseSharesFor(wallet.getId()
+                                                  .getOwner());
+            var expected = sharesPurchaseStateWhen(command);
             context().receivesCommand(command);
 
             context().assertState(command.getPurchaseProcess(), expected);
@@ -189,10 +173,10 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("which issues the `ReserveMoney` command")
         void reserveMoney() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            PurchaseShares command = purchaseSharesFor(wallet.getId()
-                                                             .getOwner());
-            ReserveMoney expected = reserveMoneyInitiatedBy(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = purchaseSharesFor(wallet.getId()
+                                                  .getOwner());
+            var expected = reserveMoneyInitiatedBy(command);
             context().receivesCommand(command);
 
             context().assertCommands()
@@ -204,10 +188,10 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("which issues the `ObtainShares` command")
         void obtainShares() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            PurchaseShares command = purchaseSharesFor(wallet.getId()
-                                                             .getOwner());
-            ObtainShares expected = obtainSharesWith(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = purchaseSharesFor(wallet.getId()
+                                                  .getOwner());
+            var expected = obtainSharesWith(command);
             context().receivesCommand(command);
 
             context().assertCommands()
@@ -219,10 +203,10 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("which issues the `AddShares` command")
         void addShares() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            PurchaseShares command = purchaseSharesFor(wallet.getId()
-                                                             .getOwner());
-            AddShares expected = addSharesWith(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = purchaseSharesFor(wallet.getId()
+                                                  .getOwner());
+            var expected = addSharesWith(command);
             context().receivesCommand(command);
 
             context().assertCommands()
@@ -234,10 +218,10 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("which issues the `DebitReservedMoney` command")
         void debitReservedMoney() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            PurchaseShares command = purchaseSharesFor(wallet.getId()
-                                                             .getOwner());
-            DebitReservedMoney expected = debitReservedMoneyWith(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = purchaseSharesFor(wallet.getId()
+                                                  .getOwner());
+            var expected = debitReservedMoneyWith(command);
             context().receivesCommand(command);
 
             context().assertCommands()
@@ -249,10 +233,10 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("which emits the `SharesPurchased` event")
         void sharesPurchased() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            PurchaseShares command = purchaseSharesFor(wallet.getId()
-                                                             .getOwner());
-            SharesPurchased expected = sharesPurchasedAsResultOf(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = purchaseSharesFor(wallet.getId()
+                                                  .getOwner());
+            var expected = sharesPurchasedAsResultOf(command);
             context().receivesCommand(command);
 
             context().assertEvent(expected);
@@ -261,9 +245,9 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("which emits the `SharesPurchaseFailed` event when insufficient funds in the wallet")
         void processFailedAfterInsufficientFunds() {
-            WalletId walletId = setUpWallet(context());
-            PurchaseShares command = purchaseSharesFor(walletId.getOwner());
-            SharesPurchaseFailed expected = sharesPurchaseFailedAsResultOf(command);
+            var walletId = setUpWallet(context());
+            var command = purchaseSharesFor(walletId.getOwner());
+            var expected = sharesPurchaseFailedAsResultOf(command);
             context().receivesCommand(command);
 
             context().assertEvent(expected);
@@ -272,10 +256,10 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("which issues the `CancelMoneyReservation` command")
         void cancelMoneyReservation() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            PurchaseShares command = purchaseSharesFor(wallet.getId()
-                                                             .getOwner());
-            CancelMoneyReservation expected = cancelMoneyReservationAfter(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = purchaseSharesFor(wallet.getId()
+                                                  .getOwner());
+            var expected = cancelMoneyReservationAfter(command);
             RejectingMarket.switchToRejectionMode();
             context().receivesCommand(command);
 
@@ -289,10 +273,10 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         @DisplayName("which emits the `SharesPurchasedFailed` event after error in the Shares Market")
         void sharesPurchaseFailed() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            PurchaseShares command = purchaseSharesFor(wallet.getId()
-                                                             .getOwner());
-            SharesPurchaseFailed expected = sharesPurchaseFailedAsResultOf(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = purchaseSharesFor(wallet.getId()
+                                                  .getOwner());
+            var expected = sharesPurchaseFailedAsResultOf(command);
             RejectingMarket.switchToRejectionMode();
             context().receivesCommand(command);
 
@@ -304,14 +288,14 @@ public final class SharesPurchaseTest extends FreshContextTest {
     @Test
     @DisplayName("increase the number of available shares in the `InvestmentView` projection")
     void state() {
-        Wallet wallet = setUpReplenishedWallet(context());
-        UserId user = wallet.getId()
-                            .getOwner();
-        ShareId share = ShareId.generate();
-        PurchaseShares firstPurchase = purchaseSharesFor(user, share);
-        PurchaseShares secondPurchase = purchaseSharesFor(user, share);
+        var wallet = setUpReplenishedWallet(context());
+        var user = wallet.getId()
+                         .getOwner();
+        var share = ShareId.generate();
+        var firstPurchase = purchaseSharesFor(user, share);
+        var secondPurchase = purchaseSharesFor(user, share);
         context().receivesCommands(firstPurchase, secondPurchase);
-        InvestmentView expected = investmentViewAfter(firstPurchase, secondPurchase);
+        var expected = investmentViewAfter(firstPurchase, secondPurchase);
 
         context().assertState(expected.getId(), expected);
     }
@@ -319,14 +303,14 @@ public final class SharesPurchaseTest extends FreshContextTest {
     @Test
     @DisplayName("reduce the balance value in the `WalletBalance` projection")
     void reduceWalletBalance() {
-        Wallet wallet = setUpReplenishedWallet(context());
-        UserId user = wallet.getId()
-                            .getOwner();
-        ShareId share = ShareId.generate();
-        PurchaseShares firstPurchase = purchaseSharesFor(user, share);
-        PurchaseShares secondPurchase = purchaseSharesFor(user, share);
+        var wallet = setUpReplenishedWallet(context());
+        var user = wallet.getId()
+                         .getOwner();
+        var share = ShareId.generate();
+        var firstPurchase = purchaseSharesFor(user, share);
+        var secondPurchase = purchaseSharesFor(user, share);
         context().receivesCommands(firstPurchase, secondPurchase);
-        WalletBalance expected = walletBalanceAfter(firstPurchase, secondPurchase, wallet);
+        var expected = walletBalanceAfter(firstPurchase, secondPurchase, wallet);
 
         context().assertState(wallet.getId(), expected);
     }

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesPurchaseTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesPurchaseTest.java
@@ -26,39 +26,23 @@
 
 package io.spine.examples.shareaware.server.investment;
 
-import io.spine.core.UserId;
-import io.spine.examples.shareaware.InvestmentId;
 import io.spine.examples.shareaware.ShareId;
-import io.spine.examples.shareaware.WalletId;
-import io.spine.examples.shareaware.investment.InvestmentView;
-import io.spine.examples.shareaware.investment.Investment;
-import io.spine.examples.shareaware.investment.SharesPurchase;
 import io.spine.examples.shareaware.investment.command.AddShares;
-import io.spine.examples.shareaware.investment.command.PurchaseShares;
-import io.spine.examples.shareaware.investment.event.SharesAdded;
-import io.spine.examples.shareaware.investment.event.SharesPurchaseFailed;
-import io.spine.examples.shareaware.investment.event.SharesPurchased;
 import io.spine.examples.shareaware.market.command.ObtainShares;
 import io.spine.examples.shareaware.server.FreshContextTest;
 import io.spine.examples.shareaware.server.investment.given.InvestmentTestContext;
 import io.spine.examples.shareaware.server.investment.given.RejectingMarket;
-import io.spine.examples.shareaware.wallet.Wallet;
-import io.spine.examples.shareaware.wallet.WalletBalance;
 import io.spine.examples.shareaware.wallet.command.CancelMoneyReservation;
 import io.spine.examples.shareaware.wallet.command.DebitReservedMoney;
 import io.spine.examples.shareaware.wallet.command.ReserveMoney;
-import io.spine.examples.shareaware.wallet.event.MoneyReservationCanceled;
-import io.spine.examples.shareaware.wallet.event.MoneyReserved;
-import io.spine.examples.shareaware.wallet.event.ReservedMoneyDebited;
-import io.spine.examples.shareaware.wallet.rejection.Rejections.InsufficientFunds;
 import io.spine.server.BoundedContextBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.examples.shareaware.server.investment.given.InvestmentTestEnv.*;
-import static io.spine.examples.shareaware.server.given.WalletTestEnv.setUpReplenishedWallet;
 import static io.spine.examples.shareaware.server.given.GivenWallet.setUpWallet;
+import static io.spine.examples.shareaware.server.given.WalletTestEnv.setUpReplenishedWallet;
+import static io.spine.examples.shareaware.server.investment.given.InvestmentTestEnv.*;
 
 @DisplayName("`SharesPurchase` should")
 public final class SharesPurchaseTest extends FreshContextTest {

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesPurchaseTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesPurchaseTest.java
@@ -60,10 +60,8 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("for the purchase price amount")
         void walletState() {
             var wallet = setUpReplenishedWallet(context());
-            var user = wallet.getId()
-                             .getOwner();
-            var firstPurchase = purchaseSharesFor(user);
-            var secondPurchase = purchaseSharesFor(user);
+            var firstPurchase = purchaseShares(wallet);
+            var secondPurchase = purchaseShares(wallet);
             var walletAfterPurchase =
                     walletAfter(firstPurchase, secondPurchase, wallet);
             context().receivesCommands(firstPurchase, secondPurchase);
@@ -75,8 +73,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("emitting the `MoneyReserved` event")
         void moneyReserved() {
             var wallet = setUpReplenishedWallet(context());
-            var command = purchaseSharesFor(wallet.getId()
-                                                  .getOwner());
+            var command = purchaseShares(wallet);
             var expected = moneyReservedBy(command);
             context().receivesCommand(command);
 
@@ -87,8 +84,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("emitting the `ReservedMoneyDebited` event")
         void reservedMoneyDebited() {
             var wallet = setUpReplenishedWallet(context());
-            var command = purchaseSharesFor(wallet.getId()
-                                                  .getOwner());
+            var command = purchaseShares(wallet);
             var expected = reservedMoneyDebitedBy(command, wallet);
             context().receivesCommand(command);
 
@@ -99,7 +95,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("emitting the `InsufficientFunds` rejection")
         void insufficientFunds() {
             var walletId = setUpWallet(context());
-            var command = purchaseSharesFor(walletId.getOwner());
+            var command = purchaseShares(walletId);
             var expected = insufficientFundsIn(walletId, command);
             context().receivesCommand(command);
 
@@ -110,8 +106,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("emitting the `MoneyReservationCanceled` event")
         void reservationCanceled() {
             var wallet = setUpReplenishedWallet(context());
-            var command = purchaseSharesFor(wallet.getId()
-                                                  .getOwner());
+            var command = purchaseShares(wallet);
             var expected = moneyReservationCanceledAfter(command);
             RejectingMarket.switchToRejectionMode();
             context().receivesCommand(command);
@@ -132,8 +127,8 @@ public final class SharesPurchaseTest extends FreshContextTest {
             var user = wallet.getId()
                              .getOwner();
             var share = ShareId.generate();
-            var firstPurchase = purchaseSharesFor(user, share);
-            var secondPurchase = purchaseSharesFor(user, share);
+            var firstPurchase = purchaseShares(wallet, share);
+            var secondPurchase = purchaseShares(wallet, share);
             var expected = investmentAfter(firstPurchase, secondPurchase);
             var investmentId = investmentId(user, share);
             context().receivesCommands(firstPurchase, secondPurchase);
@@ -144,9 +139,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @Test
         void sharesAdded() {
             var wallet = setUpReplenishedWallet(context());
-            var user = wallet.getId()
-                             .getOwner();
-            var command = purchaseSharesFor(user);
+            var command = purchaseShares(wallet);
             var expected = sharesAddedBy(command);
             context().receivesCommand(command);
 
@@ -162,8 +155,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("with state")
         void state() {
             var wallet = setUpReplenishedWallet(context());
-            var command = purchaseSharesFor(wallet.getId()
-                                                  .getOwner());
+            var command = purchaseShares(wallet);
             var expected = sharesPurchaseStateWhen(command);
             context().receivesCommand(command);
 
@@ -174,8 +166,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("which issues the `ReserveMoney` command")
         void reserveMoney() {
             var wallet = setUpReplenishedWallet(context());
-            var command = purchaseSharesFor(wallet.getId()
-                                                  .getOwner());
+            var command = purchaseShares(wallet);
             var expected = reserveMoneyInitiatedBy(command);
             context().receivesCommand(command);
 
@@ -189,8 +180,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("which issues the `ObtainShares` command")
         void obtainShares() {
             var wallet = setUpReplenishedWallet(context());
-            var command = purchaseSharesFor(wallet.getId()
-                                                  .getOwner());
+            var command = purchaseShares(wallet);
             var expected = obtainSharesWith(command);
             context().receivesCommand(command);
 
@@ -204,8 +194,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("which issues the `AddShares` command")
         void addShares() {
             var wallet = setUpReplenishedWallet(context());
-            var command = purchaseSharesFor(wallet.getId()
-                                                  .getOwner());
+            var command = purchaseShares(wallet);
             var expected = addSharesWith(command);
             context().receivesCommand(command);
 
@@ -219,8 +208,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("which issues the `DebitReservedMoney` command")
         void debitReservedMoney() {
             var wallet = setUpReplenishedWallet(context());
-            var command = purchaseSharesFor(wallet.getId()
-                                                  .getOwner());
+            var command = purchaseShares(wallet);
             var expected = debitReservedMoneyWith(command);
             context().receivesCommand(command);
 
@@ -234,8 +222,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("which emits the `SharesPurchased` event")
         void sharesPurchased() {
             var wallet = setUpReplenishedWallet(context());
-            var command = purchaseSharesFor(wallet.getId()
-                                                  .getOwner());
+            var command = purchaseShares(wallet);
             var expected = sharesPurchasedAsResultOf(command);
             context().receivesCommand(command);
 
@@ -246,7 +233,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("which emits the `SharesPurchaseFailed` event when insufficient funds in the wallet")
         void processFailedAfterInsufficientFunds() {
             var walletId = setUpWallet(context());
-            var command = purchaseSharesFor(walletId.getOwner());
+            var command = purchaseShares(walletId);
             var expected = sharesPurchaseFailedAsResultOf(command);
             context().receivesCommand(command);
 
@@ -257,8 +244,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("which issues the `CancelMoneyReservation` command")
         void cancelMoneyReservation() {
             var wallet = setUpReplenishedWallet(context());
-            var command = purchaseSharesFor(wallet.getId()
-                                                  .getOwner());
+            var command = purchaseShares(wallet);
             var expected = cancelMoneyReservationAfter(command);
             RejectingMarket.switchToRejectionMode();
             context().receivesCommand(command);
@@ -274,8 +260,7 @@ public final class SharesPurchaseTest extends FreshContextTest {
         @DisplayName("which emits the `SharesPurchasedFailed` event after error in the Shares Market")
         void sharesPurchaseFailed() {
             var wallet = setUpReplenishedWallet(context());
-            var command = purchaseSharesFor(wallet.getId()
-                                                  .getOwner());
+            var command = purchaseShares(wallet);
             var expected = sharesPurchaseFailedAsResultOf(command);
             RejectingMarket.switchToRejectionMode();
             context().receivesCommand(command);
@@ -289,11 +274,9 @@ public final class SharesPurchaseTest extends FreshContextTest {
     @DisplayName("increase the number of available shares in the `InvestmentView` projection")
     void state() {
         var wallet = setUpReplenishedWallet(context());
-        var user = wallet.getId()
-                         .getOwner();
         var share = ShareId.generate();
-        var firstPurchase = purchaseSharesFor(user, share);
-        var secondPurchase = purchaseSharesFor(user, share);
+        var firstPurchase = purchaseShares(wallet, share);
+        var secondPurchase = purchaseShares(wallet, share);
         context().receivesCommands(firstPurchase, secondPurchase);
         var expected = investmentViewAfter(firstPurchase, secondPurchase);
 
@@ -304,11 +287,9 @@ public final class SharesPurchaseTest extends FreshContextTest {
     @DisplayName("reduce the balance value in the `WalletBalance` projection")
     void reduceWalletBalance() {
         var wallet = setUpReplenishedWallet(context());
-        var user = wallet.getId()
-                         .getOwner();
         var share = ShareId.generate();
-        var firstPurchase = purchaseSharesFor(user, share);
-        var secondPurchase = purchaseSharesFor(user, share);
+        var firstPurchase = purchaseShares(wallet, share);
+        var secondPurchase = purchaseShares(wallet, share);
         context().receivesCommands(firstPurchase, secondPurchase);
         var expected = walletBalanceAfter(firstPurchase, secondPurchase, wallet);
 

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesSaleTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesSaleTest.java
@@ -60,9 +60,7 @@ public class SharesSaleTest extends FreshContextTest {
         @DisplayName("for the sell price")
         void state() {
             var wallet = setUpReplenishedWallet(context());
-            var user = wallet.getId()
-                             .getOwner();
-            var purchaseCommand = purchaseSharesFor(user);
+            var purchaseCommand = purchaseShares(wallet);
             context().receivesCommand(purchaseCommand);
 
             var sellCommand = sellShareAfter(purchaseCommand);
@@ -76,9 +74,7 @@ public class SharesSaleTest extends FreshContextTest {
         @DisplayName("emitting the `BalanceRecharged` event")
         void event() {
             var wallet = setUpReplenishedWallet(context());
-            var user = wallet.getId()
-                             .getOwner();
-            var purchaseCommand = purchaseSharesFor(user);
+            var purchaseCommand = purchaseShares(wallet);
             context().receivesCommand(purchaseCommand);
 
             var sellCommand = sellShareAfter(purchaseCommand);
@@ -171,9 +167,7 @@ public class SharesSaleTest extends FreshContextTest {
     @DisplayName("increase the amount of money in the `WalletBalance` projection")
     void increaseWalletBalance() {
         var wallet = setUpReplenishedWallet(context());
-        var user = wallet.getId()
-                         .getOwner();
-        var purchaseCommand = purchaseSharesFor(user);
+        var purchaseCommand = purchaseShares(wallet);
         context().receivesCommand(purchaseCommand);
 
         var sellCommand = sellShareAfter(purchaseCommand);

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesSaleTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/SharesSaleTest.java
@@ -26,27 +26,13 @@
 
 package io.spine.examples.shareaware.server.investment;
 
-import io.spine.core.UserId;
-import io.spine.examples.shareaware.investment.InvestmentView;
-import io.spine.examples.shareaware.investment.Investment;
-import io.spine.examples.shareaware.investment.SharesSale;
 import io.spine.examples.shareaware.investment.command.CancelSharesReservation;
 import io.spine.examples.shareaware.investment.command.CompleteSharesReservation;
-import io.spine.examples.shareaware.investment.command.PurchaseShares;
 import io.spine.examples.shareaware.investment.command.ReserveShares;
-import io.spine.examples.shareaware.investment.command.SellShares;
-import io.spine.examples.shareaware.investment.event.SharesReservationCanceled;
-import io.spine.examples.shareaware.investment.event.SharesReservationCompleted;
-import io.spine.examples.shareaware.investment.event.SharesReserved;
-import io.spine.examples.shareaware.investment.event.SharesSaleFailed;
-import io.spine.examples.shareaware.investment.event.SharesSold;
-import io.spine.examples.shareaware.investment.rejection.Rejections.InsufficientShares;
 import io.spine.examples.shareaware.market.command.SellSharesOnMarket;
 import io.spine.examples.shareaware.server.FreshContextTest;
 import io.spine.examples.shareaware.server.investment.given.InvestmentTestContext;
 import io.spine.examples.shareaware.server.investment.given.RejectingMarket;
-import io.spine.examples.shareaware.wallet.Wallet;
-import io.spine.examples.shareaware.wallet.WalletBalance;
 import io.spine.examples.shareaware.wallet.command.RechargeBalance;
 import io.spine.examples.shareaware.wallet.event.BalanceRecharged;
 import io.spine.server.BoundedContextBuilder;
@@ -54,7 +40,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.examples.shareaware.server.given.WalletTestEnv.*;
+import static io.spine.examples.shareaware.server.given.WalletTestEnv.setUpReplenishedWallet;
 import static io.spine.examples.shareaware.server.investment.given.InvestmentTestEnv.*;
 import static io.spine.examples.shareaware.server.investment.given.SharesSaleTestEnv.*;
 
@@ -73,15 +59,15 @@ public class SharesSaleTest extends FreshContextTest {
         @Test
         @DisplayName("for the sell price")
         void state() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            UserId user = wallet.getId()
-                                .getOwner();
-            PurchaseShares purchaseCommand = purchaseSharesFor(user);
+            var wallet = setUpReplenishedWallet(context());
+            var user = wallet.getId()
+                             .getOwner();
+            var purchaseCommand = purchaseSharesFor(user);
             context().receivesCommand(purchaseCommand);
 
-            SellShares sellCommand = sellShareAfter(purchaseCommand);
+            var sellCommand = sellShareAfter(purchaseCommand);
             context().receivesCommand(sellCommand);
-            Wallet expected = walletAfter(purchaseCommand, sellCommand, wallet);
+            var expected = walletAfter(purchaseCommand, sellCommand, wallet);
 
             context().assertState(wallet.getId(), expected);
         }
@@ -89,16 +75,15 @@ public class SharesSaleTest extends FreshContextTest {
         @Test
         @DisplayName("emitting the `BalanceRecharged` event")
         void event() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            UserId user = wallet.getId()
-                                .getOwner();
-            PurchaseShares purchaseCommand = purchaseSharesFor(user);
+            var wallet = setUpReplenishedWallet(context());
+            var user = wallet.getId()
+                             .getOwner();
+            var purchaseCommand = purchaseSharesFor(user);
             context().receivesCommand(purchaseCommand);
 
-            SellShares sellCommand = sellShareAfter(purchaseCommand);
+            var sellCommand = sellShareAfter(purchaseCommand);
             context().receivesCommand(sellCommand);
-            BalanceRecharged expected =
-                    balanceRechargedAfter(sellCommand, purchaseCommand, wallet);
+            var expected = balanceRechargedAfter(sellCommand, purchaseCommand, wallet);
 
             context().assertEvents()
                      .withType(BalanceRecharged.class)
@@ -114,10 +99,10 @@ public class SharesSaleTest extends FreshContextTest {
         @Test
         @DisplayName("by reducing the number of available shares")
         void state() {
-            Investment investment = setUpInvestment(context());
-            SellShares command = sellShareFrom(investment);
+            var investment = setUpInvestment(context());
+            var command = sellShareFrom(investment);
             context().receivesCommand(command);
-            Investment expected = investmentAfter(command, investment);
+            var expected = investmentAfter(command, investment);
 
             context().assertState(investment.getId(), expected);
         }
@@ -125,10 +110,10 @@ public class SharesSaleTest extends FreshContextTest {
         @Test
         @DisplayName("by emitting the `SharesReserved` event")
         void sharesReserved() {
-            Investment investment = setUpInvestment(context());
-            SellShares command = sellShareFrom(investment);
+            var investment = setUpInvestment(context());
+            var command = sellShareFrom(investment);
             context().receivesCommand(command);
-            SharesReserved expected = sharesReservedBy(command);
+            var expected = sharesReservedBy(command);
 
             context().assertEvent(expected);
         }
@@ -136,11 +121,10 @@ public class SharesSaleTest extends FreshContextTest {
         @Test
         @DisplayName("by emitting the `SharesReservationCompleted` event")
         void sharesReservationCompleted() {
-            Investment investment = setUpInvestment(context());
-            SellShares command = sellShareFrom(investment);
+            var investment = setUpInvestment(context());
+            var command = sellShareFrom(investment);
             context().receivesCommand(command);
-            SharesReservationCompleted expected =
-                    sharesReservationCompletedBy(command, investment);
+            var expected = sharesReservationCompletedBy(command, investment);
 
             context().assertEvent(expected);
         }
@@ -149,12 +133,11 @@ public class SharesSaleTest extends FreshContextTest {
         @DisplayName("by emitting the `SharesReservationCanceled event " +
                 "after error in the shares market")
         void sharesReservationCanceled() {
-            Investment investment = setUpInvestment(context());
-            SellShares command = sellShareFrom(investment);
+            var investment = setUpInvestment(context());
+            var command = sellShareFrom(investment);
             RejectingMarket.switchToRejectionMode();
             context().receivesCommand(command);
-            SharesReservationCanceled expected =
-                    sharesReservationCanceledAfter(command);
+            var expected = sharesReservationCanceledAfter(command);
 
             context().assertEvent(expected);
             RejectingMarket.switchToEventsMode();
@@ -163,10 +146,10 @@ public class SharesSaleTest extends FreshContextTest {
         @Test
         @DisplayName("by emitting the `InsufficientShares` rejection")
         void insufficientShares() {
-            Investment investment = setUpInvestment(context());
-            SellShares command = sellMoreSharesThanIn(investment);
+            var investment = setUpInvestment(context());
+            var command = sellMoreSharesThanIn(investment);
             context().receivesCommand(command);
-            InsufficientShares expected = insufficientSharesCausedBy(command);
+            var expected = insufficientSharesCausedBy(command);
 
             context().assertEvent(expected);
         }
@@ -175,11 +158,11 @@ public class SharesSaleTest extends FreshContextTest {
     @Test
     @DisplayName("reduce the number of available shares in the `InvestmentView` projection")
     void projection() {
-        Investment investment = setUpInvestment(context());
-        SellShares firstSale = sellShareFrom(investment);
-        SellShares secondSale = sellShareFrom(investment);
+        var investment = setUpInvestment(context());
+        var firstSale = sellShareFrom(investment);
+        var secondSale = sellShareFrom(investment);
         context().receivesCommands(firstSale, secondSale);
-        InvestmentView expected = investmentViewAfter(firstSale, secondSale, investment);
+        var expected = investmentViewAfter(firstSale, secondSale, investment);
 
         context().assertState(investment.getId(), expected);
     }
@@ -187,15 +170,15 @@ public class SharesSaleTest extends FreshContextTest {
     @Test
     @DisplayName("increase the amount of money in the `WalletBalance` projection")
     void increaseWalletBalance() {
-        Wallet wallet = setUpReplenishedWallet(context());
-        UserId user = wallet.getId()
-                            .getOwner();
-        PurchaseShares purchaseCommand = purchaseSharesFor(user);
+        var wallet = setUpReplenishedWallet(context());
+        var user = wallet.getId()
+                         .getOwner();
+        var purchaseCommand = purchaseSharesFor(user);
         context().receivesCommand(purchaseCommand);
 
-        SellShares sellCommand = sellShareAfter(purchaseCommand);
+        var sellCommand = sellShareAfter(purchaseCommand);
         context().receivesCommand(sellCommand);
-        WalletBalance expected = walletBalanceAfter(purchaseCommand, sellCommand, wallet);
+        var expected = walletBalanceAfter(purchaseCommand, sellCommand, wallet);
 
         context().assertState(wallet.getId(), expected);
     }
@@ -203,10 +186,10 @@ public class SharesSaleTest extends FreshContextTest {
     @Test
     @DisplayName("have an expected state")
     void state() {
-        Investment investment = setUpInvestment(context());
-        SellShares command = sellShareFrom(investment);
+        var investment = setUpInvestment(context());
+        var command = sellShareFrom(investment);
         context().receivesCommand(command);
-        SharesSale expected = sharesSaleInitiatedBy(command);
+        var expected = sharesSaleInitiatedBy(command);
 
         context().assertState(command.getSaleProcess(), expected);
     }
@@ -214,10 +197,10 @@ public class SharesSaleTest extends FreshContextTest {
     @Test
     @DisplayName("issue the `ReserveShares` command")
     void reserveShares() {
-        Investment investment = setUpInvestment(context());
-        SellShares command = sellShareFrom(investment);
+        var investment = setUpInvestment(context());
+        var command = sellShareFrom(investment);
         context().receivesCommand(command);
-        ReserveShares expected = reserveSharesWith(command);
+        var expected = reserveSharesWith(command);
 
         context().assertCommands()
                  .withType(ReserveShares.class)
@@ -228,10 +211,10 @@ public class SharesSaleTest extends FreshContextTest {
     @Test
     @DisplayName("issue the `SellSharesOnMarket` command")
     void sellSharesOnMarket() {
-        Investment investment = setUpInvestment(context());
-        SellShares command = sellShareFrom(investment);
+        var investment = setUpInvestment(context());
+        var command = sellShareFrom(investment);
         context().receivesCommand(command);
-        SellSharesOnMarket expected = sellSharesOnMarketWith(command);
+        var expected = sellSharesOnMarketWith(command);
 
         context().assertCommands()
                  .withType(SellSharesOnMarket.class)
@@ -242,10 +225,10 @@ public class SharesSaleTest extends FreshContextTest {
     @Test
     @DisplayName("issue the `RechargeBalance` command")
     void rechargeBalance() {
-        Investment investment = setUpInvestment(context());
-        SellShares command = sellShareFrom(investment);
+        var investment = setUpInvestment(context());
+        var command = sellShareFrom(investment);
         context().receivesCommand(command);
-        RechargeBalance expected = rechargeBalanceWith(command);
+        var expected = rechargeBalanceWith(command);
 
         context().assertCommands()
                  .withType(RechargeBalance.class)
@@ -256,11 +239,10 @@ public class SharesSaleTest extends FreshContextTest {
     @Test
     @DisplayName("issue the `CompleteSharesReservation` command")
     void completeSharesReservation() {
-        Investment investment = setUpInvestment(context());
-        SellShares command = sellShareFrom(investment);
+        var investment = setUpInvestment(context());
+        var command = sellShareFrom(investment);
         context().receivesCommand(command);
-        CompleteSharesReservation expected =
-                completeSharesReservationWith(command);
+        var expected = completeSharesReservationWith(command);
 
         context().assertCommands()
                  .withType(CompleteSharesReservation.class)
@@ -271,10 +253,10 @@ public class SharesSaleTest extends FreshContextTest {
     @Test
     @DisplayName("emit the `SharesSold` event")
     void sharesSold() {
-        Investment investment = setUpInvestment(context());
-        SellShares command = sellShareFrom(investment);
+        var investment = setUpInvestment(context());
+        var command = sellShareFrom(investment);
         context().receivesCommand(command);
-        SharesSold expected = sharesSoldBy(command, investment);
+        var expected = sharesSoldBy(command, investment);
 
         context().assertEvent(expected);
     }
@@ -283,10 +265,10 @@ public class SharesSaleTest extends FreshContextTest {
     @DisplayName("emit the `SharesSaleFailed` " +
             "due to insufficient quantity of shares owned")
     void sharesSaleFailedAfterInsufficientShares() {
-        Investment investment = setUpInvestment(context());
-        SellShares command = sellMoreSharesThanIn(investment);
+        var investment = setUpInvestment(context());
+        var command = sellMoreSharesThanIn(investment);
         context().receivesCommand(command);
-        SharesSaleFailed expected = sharesSaleFailedAfter(command);
+        var expected = sharesSaleFailedAfter(command);
 
         context().assertEvent(expected);
     }
@@ -295,11 +277,11 @@ public class SharesSaleTest extends FreshContextTest {
     @DisplayName("issue the `CancelSharesReservation` command " +
             "after error in the shares market")
     void cancelSharesReservation() {
-        Investment investment = setUpInvestment(context());
-        SellShares command = sellShareFrom(investment);
+        var investment = setUpInvestment(context());
+        var command = sellShareFrom(investment);
         RejectingMarket.switchToRejectionMode();
         context().receivesCommand(command);
-        CancelSharesReservation expected = cancelSharesReservationBy(command);
+        var expected = cancelSharesReservationBy(command);
 
         context().assertCommands()
                  .withType(CancelSharesReservation.class)
@@ -312,11 +294,11 @@ public class SharesSaleTest extends FreshContextTest {
     @DisplayName("emit the `SharesSaleFailed` event " +
             "after error in the shares market")
     void sharesSaleFailedAfterError() {
-        Investment investment = setUpInvestment(context());
-        SellShares command = sellShareFrom(investment);
+        var investment = setUpInvestment(context());
+        var command = sellShareFrom(investment);
         RejectingMarket.switchToRejectionMode();
         context().receivesCommand(command);
-        SharesSaleFailed expected = sharesSaleFailedAfter(command);
+        var expected = sharesSaleFailedAfter(command);
 
         context().assertEvent(expected);
         context().assertState(investment.getId(), investment);

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
@@ -75,18 +75,26 @@ public final class InvestmentTestEnv {
     private InvestmentTestEnv() {
     }
 
-    public static PurchaseShares purchaseSharesFor(UserId purchaser) {
-        return purchaseSharesFor(purchaser, ShareId.generate());
+    public static PurchaseShares purchaseShares(Wallet wallet) {
+        return purchaseShares(wallet.getId(), ShareId.generate());
     }
 
-    public static PurchaseShares purchaseSharesFor(UserId purchaser, ShareId share) {
+    public static PurchaseShares purchaseShares(WalletId wallet) {
+        return purchaseShares(wallet, ShareId.generate());
+    }
+
+    public static PurchaseShares purchaseShares(Wallet wallet, ShareId share) {
+        return purchaseShares(wallet.getId(), share);
+    }
+
+    private static PurchaseShares purchaseShares(WalletId wallet, ShareId share) {
         return PurchaseShares
                 .newBuilder()
                 .setShare(share)
                 .setPurchaseProcess(PurchaseId.generate())
                 .setQuantity(5)
                 .setPrice(usd(20))
-                .setPurchaser(purchaser)
+                .setPurchaser(wallet.getOwner())
                 .vBuild();
     }
 
@@ -243,7 +251,7 @@ public final class InvestmentTestEnv {
         var wallet = setUpReplenishedWallet(context);
         var user = wallet.getId()
                          .getOwner();
-        var command = purchaseSharesFor(user);
+        var command = purchaseShares(wallet);
         context.receivesCommand(command);
         return Investment
                 .newBuilder()

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/InvestmentTestEnv.java
@@ -28,12 +28,12 @@ package io.spine.examples.shareaware.server.investment.given;
 
 import io.spine.core.UserId;
 import io.spine.examples.shareaware.InvestmentId;
-import io.spine.examples.shareaware.WithdrawalOperationId;
 import io.spine.examples.shareaware.PurchaseId;
 import io.spine.examples.shareaware.ShareId;
 import io.spine.examples.shareaware.WalletId;
-import io.spine.examples.shareaware.investment.InvestmentView;
+import io.spine.examples.shareaware.WithdrawalOperationId;
 import io.spine.examples.shareaware.investment.Investment;
+import io.spine.examples.shareaware.investment.InvestmentView;
 import io.spine.examples.shareaware.investment.SharesPurchase;
 import io.spine.examples.shareaware.investment.command.AddShares;
 import io.spine.examples.shareaware.investment.command.CancelSharesReservation;
@@ -60,13 +60,12 @@ import io.spine.examples.shareaware.wallet.event.MoneyReservationCanceled;
 import io.spine.examples.shareaware.wallet.event.MoneyReserved;
 import io.spine.examples.shareaware.wallet.event.ReservedMoneyDebited;
 import io.spine.examples.shareaware.wallet.rejection.Rejections.InsufficientFunds;
-import io.spine.money.Money;
 import io.spine.testing.server.blackbox.BlackBoxContext;
 
-import static io.spine.examples.shareaware.given.GivenMoney.usd;
-import static io.spine.examples.shareaware.server.given.WalletTestEnv.*;
 import static io.spine.examples.shareaware.MoneyCalculator.subtract;
 import static io.spine.examples.shareaware.MoneyCalculator.sum;
+import static io.spine.examples.shareaware.given.GivenMoney.usd;
+import static io.spine.examples.shareaware.server.given.WalletTestEnv.setUpReplenishedWallet;
 
 public final class InvestmentTestEnv {
 
@@ -94,9 +93,9 @@ public final class InvestmentTestEnv {
     public static Wallet walletAfter(PurchaseShares firstPurchase,
                                      PurchaseShares secondPurchase,
                                      Wallet wallet) {
-        Money totalPrice = sum(firstPurchase.totalCost(),
-                               secondPurchase.totalCost());
-        Money newBalance = subtract(wallet.getBalance(), totalPrice);
+        var totalPrice = sum(firstPurchase.totalCost(),
+                             secondPurchase.totalCost());
+        var newBalance = subtract(wallet.getBalance(), totalPrice);
         return wallet
                 .toBuilder()
                 .setBalance(newBalance)
@@ -114,7 +113,7 @@ public final class InvestmentTestEnv {
 
     public static ReservedMoneyDebited
     reservedMoneyDebitedBy(PurchaseShares command, Wallet wallet) {
-        Money newBalance = subtract(wallet.getBalance(), command.totalCost());
+        var newBalance = subtract(wallet.getBalance(), command.totalCost());
         return ReservedMoneyDebited
                 .newBuilder()
                 .setWallet(wallet.getId())
@@ -162,8 +161,8 @@ public final class InvestmentTestEnv {
     }
 
     public static AddShares addSharesWith(PurchaseShares command) {
-        UserId purchaser = command.getPurchaser();
-        ShareId share = command.getShare();
+        var purchaser = command.getPurchaser();
+        var share = command.getShare();
         return AddShares
                 .newBuilder()
                 .setInvestment(investmentId(purchaser, share))
@@ -201,9 +200,9 @@ public final class InvestmentTestEnv {
 
     public static Investment investmentAfter(PurchaseShares firstPurchase,
                                              PurchaseShares secondPurchase) {
-        UserId purchaser = firstPurchase.getPurchaser();
-        ShareId share = firstPurchase.getShare();
-        int availableShares = firstPurchase.getQuantity() + secondPurchase.getQuantity();
+        var purchaser = firstPurchase.getPurchaser();
+        var share = firstPurchase.getShare();
+        var availableShares = firstPurchase.getQuantity() + secondPurchase.getQuantity();
         return Investment
                 .newBuilder()
                 .setSharesAvailable(availableShares)
@@ -230,8 +229,8 @@ public final class InvestmentTestEnv {
     }
 
     public static SharesAdded sharesAddedBy(PurchaseShares command) {
-        UserId purchaser = command.getPurchaser();
-        ShareId share = command.getShare();
+        var purchaser = command.getPurchaser();
+        var share = command.getShare();
         return SharesAdded
                 .newBuilder()
                 .setProcess(command.getPurchaseProcess())
@@ -241,10 +240,10 @@ public final class InvestmentTestEnv {
     }
 
     public static Investment setUpInvestment(BlackBoxContext context) {
-        Wallet wallet = setUpReplenishedWallet(context);
-        UserId user = wallet.getId()
-                            .getOwner();
-        PurchaseShares command = purchaseSharesFor(user);
+        var wallet = setUpReplenishedWallet(context);
+        var user = wallet.getId()
+                         .getOwner();
+        var command = purchaseSharesFor(user);
         context.receivesCommand(command);
         return Investment
                 .newBuilder()
@@ -264,7 +263,7 @@ public final class InvestmentTestEnv {
 
     public static Investment investmentAfter(SellShares command,
                                              Investment investment) {
-        int newSharesAvailable = investment.getSharesAvailable() - command.getQuantity();
+        var newSharesAvailable = investment.getSharesAvailable() - command.getQuantity();
         return Investment
                 .newBuilder()
                 .setId(investmentId(command))
@@ -274,7 +273,7 @@ public final class InvestmentTestEnv {
 
     public static SharesReservationCompleted
     sharesReservationCompletedBy(SellShares command, Investment investment) {
-        int newSharesAvailable = investment.getSharesAvailable() - command.getQuantity();
+        var newSharesAvailable = investment.getSharesAvailable() - command.getQuantity();
         return SharesReservationCompleted
                 .newBuilder()
                 .setProcess(command.getSaleProcess())
@@ -330,9 +329,9 @@ public final class InvestmentTestEnv {
 
     public static InvestmentView investmentViewAfter(PurchaseShares firstPurchase,
                                                      PurchaseShares secondPurchase) {
-        UserId user = firstPurchase.getPurchaser();
-        ShareId share = firstPurchase.getShare();
-        int sharesAvailable = firstPurchase.getQuantity() + secondPurchase.getQuantity();
+        var user = firstPurchase.getPurchaser();
+        var share = firstPurchase.getShare();
+        var sharesAvailable = firstPurchase.getQuantity() + secondPurchase.getQuantity();
         return InvestmentView
                 .newBuilder()
                 .setId(investmentId(user, share))
@@ -343,9 +342,9 @@ public final class InvestmentTestEnv {
     public static WalletBalance walletBalanceAfter(PurchaseShares firstPurchase,
                                                    PurchaseShares secondPurchase,
                                                    Wallet wallet) {
-        Money totalPrice = sum(firstPurchase.totalCost(),
-                               secondPurchase.totalCost());
-        Money currentBalance = subtract(wallet.getBalance(), totalPrice);
+        var totalPrice = sum(firstPurchase.totalCost(),
+                             secondPurchase.totalCost());
+        var currentBalance = subtract(wallet.getBalance(), totalPrice);
         return WalletBalance
                 .newBuilder()
                 .setId(wallet.getId())

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/RejectingMarket.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/RejectingMarket.java
@@ -34,7 +34,6 @@ import io.spine.examples.shareaware.market.event.SharesObtained;
 import io.spine.examples.shareaware.market.event.SharesSoldOnMarket;
 import io.spine.examples.shareaware.market.rejection.SharesCannotBeObtained;
 import io.spine.examples.shareaware.market.rejection.SharesCannotBeSoldOnMarket;
-import io.spine.money.Money;
 import io.spine.server.command.Assign;
 import io.spine.server.procman.ProcessManager;
 
@@ -80,7 +79,7 @@ public class RejectingMarket
                     .setSaleProcess(c.getSaleProcess())
                     .build();
         }
-        Money sellPrice = multiply(c.getPrice(), c.getQuantity());
+        var sellPrice = multiply(c.getPrice(), c.getQuantity());
         return SharesSoldOnMarket
                 .newBuilder()
                 .setMarket(c.getMarket())

--- a/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/investment/given/SharesSaleTestEnv.java
@@ -31,15 +31,15 @@ import io.spine.examples.shareaware.ReplenishmentOperationId;
 import io.spine.examples.shareaware.SaleId;
 import io.spine.examples.shareaware.ShareId;
 import io.spine.examples.shareaware.WalletId;
-import io.spine.examples.shareaware.investment.InvestmentView;
+import io.spine.examples.shareaware.given.GivenMoney;
 import io.spine.examples.shareaware.investment.Investment;
+import io.spine.examples.shareaware.investment.InvestmentView;
 import io.spine.examples.shareaware.investment.SharesSale;
 import io.spine.examples.shareaware.investment.command.PurchaseShares;
 import io.spine.examples.shareaware.investment.command.SellShares;
 import io.spine.examples.shareaware.investment.event.SharesSaleFailed;
 import io.spine.examples.shareaware.investment.event.SharesSold;
 import io.spine.examples.shareaware.market.command.SellSharesOnMarket;
-import io.spine.examples.shareaware.given.GivenMoney;
 import io.spine.examples.shareaware.server.market.MarketProcess;
 import io.spine.examples.shareaware.wallet.Wallet;
 import io.spine.examples.shareaware.wallet.WalletBalance;
@@ -63,18 +63,18 @@ public final class SharesSaleTestEnv {
     }
 
     public static SellShares sellShareFrom(Investment investment) {
-        UserId user = investment.getId()
-                                .getOwner();
-        ShareId share = investment.getId()
-                                  .getShare();
+        var user = investment.getId()
+                             .getOwner();
+        var share = investment.getId()
+                              .getShare();
         return sellShares(user, share, 1);
     }
 
     public static SellShares sellMoreSharesThanIn(Investment investment) {
-        UserId user = investment.getId()
-                                .getOwner();
-        ShareId share = investment.getId()
-                                  .getShare();
+        var user = investment.getId()
+                             .getOwner();
+        var share = investment.getId()
+                              .getShare();
         return sellShares(user, share, investment.getSharesAvailable() + 1);
     }
 
@@ -94,7 +94,7 @@ public final class SharesSaleTestEnv {
     public static Wallet walletAfter(PurchaseShares purchaseCommand,
                                      SellShares saleCommand,
                                      Wallet wallet) {
-        Money currentBalance = subtract(wallet.getBalance(), purchaseCommand.totalCost());
+        var currentBalance = subtract(wallet.getBalance(), purchaseCommand.totalCost());
         return wallet
                 .toBuilder()
                 .setBalance(sum(currentBalance, saleCommand.totalCost()))
@@ -102,16 +102,15 @@ public final class SharesSaleTestEnv {
     }
 
     public static BalanceRecharged balanceRechargedBy(SellShares command, Wallet wallet) {
-        Money currentBalance = sum(wallet.getBalance(), command.totalCost());
+        var currentBalance = sum(wallet.getBalance(), command.totalCost());
         return balanceRecharged(command, currentBalance);
     }
 
     public static BalanceRecharged balanceRechargedAfter(SellShares saleCommand,
                                                          PurchaseShares purchaseCommand,
                                                          Wallet wallet) {
-        Money balanceAfterPurchase = subtract(wallet.getBalance(),
-                                              purchaseCommand.totalCost());
-        Money currentBalance = sum(balanceAfterPurchase, saleCommand.totalCost());
+        var balanceAfterPurchase = subtract(wallet.getBalance(), purchaseCommand.totalCost());
+        var currentBalance = sum(balanceAfterPurchase, saleCommand.totalCost());
         return balanceRecharged(saleCommand, currentBalance);
     }
 
@@ -155,7 +154,7 @@ public final class SharesSaleTestEnv {
     }
 
     public static SharesSold sharesSoldBy(SellShares command, Investment investment) {
-        int sharesAvailable = investment.getSharesAvailable() - command.getQuantity();
+        var sharesAvailable = investment.getSharesAvailable() - command.getQuantity();
         return SharesSold
                 .newBuilder()
                 .setSaleProcess(command.getSaleProcess())
@@ -177,8 +176,8 @@ public final class SharesSaleTestEnv {
     public static InvestmentView investmentViewAfter(SellShares firstSale,
                                                      SellShares secondSale,
                                                      Investment investment) {
-        int saleAmount = firstSale.getQuantity() + secondSale.getQuantity();
-        int sharesAvailable = investment.getSharesAvailable() - saleAmount;
+        var saleAmount = firstSale.getQuantity() + secondSale.getQuantity();
+        var sharesAvailable = investment.getSharesAvailable() - saleAmount;
         return InvestmentView
                 .newBuilder()
                 .setId(investment.getId())
@@ -189,9 +188,8 @@ public final class SharesSaleTestEnv {
     public static WalletBalance walletBalanceAfter(PurchaseShares purchaseCommand,
                                                    SellShares sellCommand,
                                                    Wallet wallet) {
-        Money balanceAfterPurchase =
-                subtract(wallet.getBalance(), purchaseCommand.totalCost());
-        Money currentBalance = sum(balanceAfterPurchase, sellCommand.totalCost());
+        var balanceAfterPurchase = subtract(wallet.getBalance(), purchaseCommand.totalCost());
+        var currentBalance = sum(balanceAfterPurchase, sellCommand.totalCost());
         return WalletBalance
                 .newBuilder()
                 .setId(wallet.getId())

--- a/server/src/test/java/io/spine/examples/shareaware/server/market/AvailableMarketSharesTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/market/AvailableMarketSharesTest.java
@@ -26,8 +26,6 @@
 
 package io.spine.examples.shareaware.server.market;
 
-import io.spine.examples.shareaware.market.AvailableMarketShares;
-import io.spine.examples.shareaware.market.event.MarketSharesUpdated;
 import io.spine.examples.shareaware.server.FreshContextTest;
 import io.spine.examples.shareaware.server.market.given.MarketTestContext;
 import io.spine.server.BoundedContextBuilder;
@@ -64,9 +62,9 @@ final class AvailableMarketSharesTest extends FreshContextTest {
     @Test
     @DisplayName("subscribe to the external event `MarketSharesUpdated` and update its state")
     void state() {
-        MarketSharesUpdated event = marketSharesUpdated();
+        var event = marketSharesUpdated();
         marketData.emittedEvent(event, newUuid());
-        AvailableMarketShares expected = availableMarketSharesAfter(event);
+        var expected = availableMarketSharesAfter(event);
 
         context().assertState(MarketProcess.ID, expected);
     }

--- a/server/src/test/java/io/spine/examples/shareaware/server/market/MarketDataTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/market/MarketDataTest.java
@@ -50,11 +50,11 @@ final class MarketDataTest extends UtilityClassTest<MarketData> {
         List<Share> secondResult = MarketData.actualShares();
         assertThat(firstResult).hasSize(secondResult.size());
 
-        for (int i = 0; i < firstResult.size(); i++) {
-            Share shareFromFirst = firstResult.get(i);
-            Share shareFromSecond = secondResult.get(i);
-            Share shareFromFirstWithoutPrice = shareWithoutPrice(shareFromFirst);
-            Share shareFromSecondWithoutPrice = shareWithoutPrice(shareFromSecond);
+        for (var i = 0; i < firstResult.size(); i++) {
+            var shareFromFirst = firstResult.get(i);
+            var shareFromSecond = secondResult.get(i);
+            var shareFromFirstWithoutPrice = shareWithoutPrice(shareFromFirst);
+            var shareFromSecondWithoutPrice = shareWithoutPrice(shareFromSecond);
             assertThat(shareFromFirstWithoutPrice).isEqualTo(shareFromSecondWithoutPrice);
         }
     }

--- a/server/src/test/java/io/spine/examples/shareaware/server/market/MarketProcessTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/market/MarketProcessTest.java
@@ -26,15 +26,6 @@
 
 package io.spine.examples.shareaware.server.market;
 
-import io.spine.examples.shareaware.market.Market;
-import io.spine.examples.shareaware.market.command.CloseMarket;
-import io.spine.examples.shareaware.market.command.ObtainShares;
-import io.spine.examples.shareaware.market.command.OpenMarket;
-import io.spine.examples.shareaware.market.command.SellSharesOnMarket;
-import io.spine.examples.shareaware.market.event.MarketClosed;
-import io.spine.examples.shareaware.market.event.MarketOpened;
-import io.spine.examples.shareaware.market.rejection.Rejections.SharesCannotBeSoldOnMarket;
-import io.spine.examples.shareaware.market.rejection.Rejections.SharesCannotBeObtained;
 import io.spine.examples.shareaware.server.FreshContextTest;
 import io.spine.examples.shareaware.server.market.given.MarketTestContext;
 import io.spine.server.BoundedContextBuilder;
@@ -54,12 +45,12 @@ public final class MarketProcessTest extends FreshContextTest {
     @Test
     @DisplayName("change state after `OpenMarket` command")
     void stateWhenOpened() {
-        CloseMarket commandToClose = closeMarket();
+        var commandToClose = closeMarket();
         context().receivesCommand(commandToClose);
 
-        OpenMarket commandToOpen = openMarket();
+        var commandToOpen = openMarket();
         context().receivesCommand(commandToOpen);
-        Market expected = marketAfter(commandToOpen);
+        var expected = marketAfter(commandToOpen);
 
         context().assertState(commandToOpen.getMarket(), expected);
     }
@@ -67,9 +58,9 @@ public final class MarketProcessTest extends FreshContextTest {
     @Test
     @DisplayName("change state after `CloseMarket` command")
     void stateWhenClosed() {
-        CloseMarket command = closeMarket();
+        var command = closeMarket();
         context().receivesCommand(command);
-        Market expected = marketAfter(command);
+        var expected = marketAfter(command);
 
         context().assertState(command.getMarket(), expected);
     }
@@ -77,9 +68,9 @@ public final class MarketProcessTest extends FreshContextTest {
     @Test
     @DisplayName("emit the `MarketOpened` event")
     void marketOpened() {
-        OpenMarket command = openMarket();
+        var command = openMarket();
         context().receivesCommand(command);
-        MarketOpened expected = marketOpenedAfter(command);
+        var expected = marketOpenedAfter(command);
 
         context().assertEvent(expected);
     }
@@ -87,9 +78,9 @@ public final class MarketProcessTest extends FreshContextTest {
     @Test
     @DisplayName("emit the `MarketClosed` event")
     void marketClosed() {
-        CloseMarket command = closeMarket();
+        var command = closeMarket();
         context().receivesCommand(command);
-        MarketClosed expected = marketClosedAfter(command);
+        var expected = marketClosedAfter(command);
 
         context().assertEvent(expected);
     }
@@ -98,12 +89,12 @@ public final class MarketProcessTest extends FreshContextTest {
     @DisplayName("throw rejection to the response for the " +
             "`ObtainShares` command when the market is closed")
     void sharesCannotBeObtained() {
-        CloseMarket commandToCloseMarket = closeMarket();
+        var commandToCloseMarket = closeMarket();
         context().receivesCommand(commandToCloseMarket);
 
-        ObtainShares commandToObtainShares = obtainShares();
+        var commandToObtainShares = obtainShares();
         context().receivesCommand(commandToObtainShares);
-        SharesCannotBeObtained expected =
+        var expected =
                 sharesCannotBeObtainedCausedBy(commandToObtainShares);
 
         context().assertEvent(expected);
@@ -113,12 +104,12 @@ public final class MarketProcessTest extends FreshContextTest {
     @DisplayName("throw rejection to the response for the " +
             "`SellSharesOnMarket` command when the market is closed")
     void sharesCannotBeSoldOnMarket() {
-        CloseMarket commandToCloseMarket = closeMarket();
+        var commandToCloseMarket = closeMarket();
         context().receivesCommand(commandToCloseMarket);
 
-        SellSharesOnMarket commandToSellShares = sellSharesOnMarket();
+        var commandToSellShares = sellSharesOnMarket();
         context().receivesCommand(commandToSellShares);
-        SharesCannotBeSoldOnMarket expected =
+        var expected =
                 sharesCannotBeSoldOnMarketCausedBy(commandToSellShares);
 
         context().assertEvent(expected);

--- a/server/src/test/java/io/spine/examples/shareaware/server/market/MarketProcessTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/market/MarketProcessTest.java
@@ -94,8 +94,7 @@ public final class MarketProcessTest extends FreshContextTest {
 
         var commandToObtainShares = obtainShares();
         context().receivesCommand(commandToObtainShares);
-        var expected =
-                sharesCannotBeObtainedCausedBy(commandToObtainShares);
+        var expected = sharesCannotBeObtainedCausedBy(commandToObtainShares);
 
         context().assertEvent(expected);
     }
@@ -109,8 +108,7 @@ public final class MarketProcessTest extends FreshContextTest {
 
         var commandToSellShares = sellSharesOnMarket();
         context().receivesCommand(commandToSellShares);
-        var expected =
-                sharesCannotBeSoldOnMarketCausedBy(commandToSellShares);
+        var expected = sharesCannotBeSoldOnMarketCausedBy(commandToSellShares);
 
         context().assertEvent(expected);
     }

--- a/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletBalanceProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletBalanceProjectionTest.java
@@ -26,10 +26,7 @@
 
 package io.spine.examples.shareaware.server.wallet;
 
-import io.spine.examples.shareaware.WalletId;
 import io.spine.examples.shareaware.server.TradingContext;
-import io.spine.examples.shareaware.wallet.WalletBalance;
-import io.spine.examples.shareaware.wallet.command.CreateWallet;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.testing.server.blackbox.ContextAwareTest;
 import org.junit.jupiter.api.DisplayName;
@@ -48,9 +45,9 @@ public final class WalletBalanceProjectionTest extends ContextAwareTest {
     @Test
     @DisplayName("display a zero balance, as soon as the wallet created")
     void balance() {
-        WalletId wallet = givenId();
-        CreateWallet command  = createWallet(wallet);
-        WalletBalance expected = zeroWalletBalance(command.getWallet());
+        var wallet = givenId();
+        var command  = createWallet(wallet);
+        var expected = zeroWalletBalance(command.getWallet());
         context().receivesCommand(command);
 
         context().assertState(command.getWallet(), expected);

--- a/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletReplenishmentTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletReplenishmentTest.java
@@ -26,19 +26,11 @@
 
 package io.spine.examples.shareaware.server.wallet;
 
-import io.spine.examples.shareaware.WalletId;
 import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyFromUser;
 import io.spine.examples.shareaware.server.FreshContextTest;
 import io.spine.examples.shareaware.server.given.RejectingPaymentProcess;
 import io.spine.examples.shareaware.server.given.WalletTestContext;
-import io.spine.examples.shareaware.wallet.Wallet;
-import io.spine.examples.shareaware.wallet.WalletBalance;
-import io.spine.examples.shareaware.wallet.WalletReplenishment;
 import io.spine.examples.shareaware.wallet.command.RechargeBalance;
-import io.spine.examples.shareaware.wallet.event.BalanceRecharged;
-import io.spine.examples.shareaware.wallet.command.ReplenishWallet;
-import io.spine.examples.shareaware.wallet.event.WalletNotReplenished;
-import io.spine.examples.shareaware.wallet.event.WalletReplenished;
 import io.spine.server.BoundedContextBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -62,12 +54,12 @@ public final class WalletReplenishmentTest extends FreshContextTest {
         @Test
         @DisplayName("for 1000 USD")
         void entity() {
-            WalletId wallet = setUpWallet(context());
-            ReplenishWallet firstReplenishment = replenish(wallet);
-            ReplenishWallet secondReplenishment = replenish(wallet);
-            Wallet expectedWallet = walletReplenishedBy(firstReplenishment,
-                                                        secondReplenishment,
-                                                        wallet);
+            var wallet = setUpWallet(context());
+            var firstReplenishment = replenish(wallet);
+            var secondReplenishment = replenish(wallet);
+            var expectedWallet = walletReplenishedBy(firstReplenishment,
+                                                     secondReplenishment,
+                                                     wallet);
             context().receivesCommands(firstReplenishment, secondReplenishment);
 
             context().assertState(wallet, expectedWallet);
@@ -76,9 +68,9 @@ public final class WalletReplenishmentTest extends FreshContextTest {
         @Test
         @DisplayName("emitting the `BalanceRecharged` event")
         void event() {
-            WalletId wallet = setUpWallet(context());
-            ReplenishWallet command = replenish(wallet);
-            BalanceRecharged expected = balanceRechargedBy(command, wallet);
+            var wallet = setUpWallet(context());
+            var command = replenish(wallet);
+            var expected = balanceRechargedBy(command, wallet);
             context().receivesCommand(command);
 
             context().assertEvent(expected);
@@ -92,12 +84,12 @@ public final class WalletReplenishmentTest extends FreshContextTest {
         @Test
         @DisplayName("to 1000 USD")
         void balance() {
-            WalletId wallet = setUpWallet(context());
-            ReplenishWallet firstReplenishment = replenish(wallet);
-            ReplenishWallet secondReplenishment = replenish(wallet);
-            WalletBalance expected = walletBalanceAfterReplenishment(firstReplenishment,
-                                                                     secondReplenishment,
-                                                                     wallet);
+            var wallet = setUpWallet(context());
+            var firstReplenishment = replenish(wallet);
+            var secondReplenishment = replenish(wallet);
+            var expected = walletBalanceAfterReplenishment(firstReplenishment,
+                                                           secondReplenishment,
+                                                           wallet);
             context().receivesCommands(firstReplenishment, secondReplenishment);
 
             context().assertState(wallet, expected);
@@ -111,9 +103,9 @@ public final class WalletReplenishmentTest extends FreshContextTest {
         @Test
         @DisplayName("with state")
         void entity() {
-            WalletId wallet = setUpWallet(context());
-            ReplenishWallet command = replenish(wallet);
-            WalletReplenishment expectedReplenishment = walletReplenishmentBy(command);
+            var wallet = setUpWallet(context());
+            var command = replenish(wallet);
+            var expectedReplenishment = walletReplenishmentBy(command);
             context().receivesCommand(command);
 
             context().assertState(command.getReplenishment(), expectedReplenishment);
@@ -122,10 +114,9 @@ public final class WalletReplenishmentTest extends FreshContextTest {
         @Test
         @DisplayName("which sends the `TransferMoney` command")
         void commandToTransferMoney() {
-            WalletId wallet = setUpWallet(context());
-            ReplenishWallet command = replenish(wallet);
-            TransferMoneyFromUser expected =
-                    transferMoneyFromUserBy(command, shareAwareIban);
+            var wallet = setUpWallet(context());
+            var command = replenish(wallet);
+            var expected = transferMoneyFromUserBy(command, shareAwareIban);
             context().receivesCommand(command);
 
             context().assertCommands()
@@ -137,9 +128,9 @@ public final class WalletReplenishmentTest extends FreshContextTest {
         @Test
         @DisplayName("which sends the `RechargeBalance` command")
         void commandToRechargeBalance() {
-            WalletId wallet = setUpWallet(context());
-            ReplenishWallet command = replenish(wallet);
-            RechargeBalance expected = rechargeBalanceWhen(command);
+            var wallet = setUpWallet(context());
+            var command = replenish(wallet);
+            var expected = rechargeBalanceWhen(command);
             context().receivesCommand(command);
 
             context().assertCommands()
@@ -151,14 +142,13 @@ public final class WalletReplenishmentTest extends FreshContextTest {
         @Test
         @DisplayName("which emits the `WalletReplenished` event and archives itself after it")
         void event() {
-            WalletId wallet = setUpWallet(context());
-            ReplenishWallet command = replenish(wallet);
-            WalletReplenished event = walletReplenishedAfter(command);
+            var wallet = setUpWallet(context());
+            var command = replenish(wallet);
+            var event = walletReplenishedAfter(command);
             context().receivesCommand(command);
 
             context().assertEvent(event);
-            context().assertEntity(command.getReplenishment(),
-                                   WalletReplenishmentProcess.class)
+            context().assertEntity(command.getReplenishment(), WalletReplenishmentProcess.class)
                      .archivedFlag()
                      .isTrue();
         }
@@ -166,9 +156,9 @@ public final class WalletReplenishmentTest extends FreshContextTest {
         @Test
         @DisplayName("which emits the `WalletNotReplenished` event and archives itself after it")
         void rejection() {
-            WalletId wallet = setUpWallet(context());
-            ReplenishWallet command = replenish(wallet);
-            WalletNotReplenished expected = walletNotReplenishedAfter(command);
+            var wallet = setUpWallet(context());
+            var command = replenish(wallet);
+            var expected = walletNotReplenishedAfter(command);
             RejectingPaymentProcess.switchToRejectionMode();
             context().receivesCommand(command);
 

--- a/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletTest.java
@@ -26,14 +26,10 @@
 
 package io.spine.examples.shareaware.server.wallet;
 
-import io.spine.examples.shareaware.WalletId;
-import io.spine.examples.shareaware.server.TradingContext;
 import io.spine.examples.shareaware.given.GivenMoney;
-import io.spine.examples.shareaware.wallet.Wallet;
-import io.spine.examples.shareaware.wallet.command.CreateWallet;
+import io.spine.examples.shareaware.server.TradingContext;
 import io.spine.examples.shareaware.wallet.event.WalletCreated;
 import io.spine.server.BoundedContextBuilder;
-import io.spine.testing.server.EventSubject;
 import io.spine.testing.server.blackbox.ContextAwareTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,12 +47,12 @@ public final class WalletTest extends ContextAwareTest {
     @Test
     @DisplayName("allow the creation and emit the `WalletCreated` event")
     void event() {
-        WalletId wallet = givenId();
-        CreateWallet command = createWallet(wallet);
-        WalletCreated expectedEvent = walletCreatedWith(GivenMoney.zero(), wallet);
-        Wallet expectedState = walletWith(GivenMoney.zero(), wallet);
+        var wallet = givenId();
+        var command = createWallet(wallet);
+        var expectedEvent = walletCreatedWith(GivenMoney.zero(), wallet);
+        var expectedState = walletWith(GivenMoney.zero(), wallet);
         context().receivesCommand(command);
-        EventSubject assertEvents = context()
+        var assertEvents = context()
                 .assertEvents()
                 .withType(WalletCreated.class);
 

--- a/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletWithdrawalTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletWithdrawalTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import static io.spine.examples.shareaware.server.given.GivenWallet.setUpWallet;
 import static io.spine.examples.shareaware.server.given.WalletTestEnv.*;
 import static io.spine.examples.shareaware.server.wallet.WalletReplenishmentProcess.*;
 

--- a/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletWithdrawalTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/wallet/WalletWithdrawalTest.java
@@ -26,26 +26,13 @@
 
 package io.spine.examples.shareaware.server.wallet;
 
-import io.spine.examples.shareaware.WalletId;
-import io.spine.examples.shareaware.WithdrawalId;
 import io.spine.examples.shareaware.paymentgateway.command.TransferMoneyToUser;
-import io.spine.examples.shareaware.paymentgateway.event.MoneyTransferredToUser;
 import io.spine.examples.shareaware.server.FreshContextTest;
-import io.spine.examples.shareaware.server.given.WalletTestContext;
 import io.spine.examples.shareaware.server.given.RejectingPaymentProcess;
-import io.spine.examples.shareaware.wallet.Wallet;
-import io.spine.examples.shareaware.wallet.WalletBalance;
-import io.spine.examples.shareaware.wallet.WalletWithdrawal;
+import io.spine.examples.shareaware.server.given.WalletTestContext;
 import io.spine.examples.shareaware.wallet.command.CancelMoneyReservation;
 import io.spine.examples.shareaware.wallet.command.DebitReservedMoney;
 import io.spine.examples.shareaware.wallet.command.ReserveMoney;
-import io.spine.examples.shareaware.wallet.command.WithdrawMoney;
-import io.spine.examples.shareaware.wallet.event.MoneyNotWithdrawn;
-import io.spine.examples.shareaware.wallet.event.MoneyReservationCanceled;
-import io.spine.examples.shareaware.wallet.event.MoneyReserved;
-import io.spine.examples.shareaware.wallet.event.MoneyWithdrawn;
-import io.spine.examples.shareaware.wallet.event.ReservedMoneyDebited;
-import io.spine.examples.shareaware.wallet.rejection.Rejections.InsufficientFunds;
 import io.spine.server.BoundedContextBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -69,12 +56,12 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("for expected amount of money")
         void entity() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney firstWithdraw = withdrawMoneyFrom(wallet.getId());
-            WithdrawMoney secondWithdraw = withdrawMoneyFrom(wallet.getId());
-            Wallet expectedWallet = walletWhichWasWithdrawnBy(firstWithdraw,
-                                                              secondWithdraw,
-                                                              wallet);
+            var wallet = setUpReplenishedWallet(context());
+            var firstWithdraw = withdrawMoneyFrom(wallet.getId());
+            var secondWithdraw = withdrawMoneyFrom(wallet.getId());
+            var expectedWallet = walletWhichWasWithdrawnBy(firstWithdraw,
+                                                           secondWithdraw,
+                                                           wallet);
             context().receivesCommands(firstWithdraw, secondWithdraw);
 
             context().assertState(wallet.getId(), expectedWallet);
@@ -83,9 +70,9 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("emitting the `ReservedMoneyDebited` event")
         void debitMoney() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet.getId());
-            ReservedMoneyDebited expected = reservedMoneyDebitedFrom(wallet, command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = withdrawMoneyFrom(wallet.getId());
+            var expected = reservedMoneyDebitedFrom(wallet, command);
             context().receivesCommand(command);
 
             context().assertEvent(expected);
@@ -94,9 +81,9 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("emitting the `MoneyReserved` event")
         void reserveMoney() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet.getId());
-            MoneyReserved expected = moneyReservedBy(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = withdrawMoneyFrom(wallet.getId());
+            var expected = moneyReservedBy(command);
             context().receivesCommand(command);
 
             context().assertEvent(expected);
@@ -105,9 +92,9 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("emitting the `InsufficientFunds` rejection")
         void insufficientFunds() {
-            WalletId wallet = setUpWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet);
-            InsufficientFunds expected = insufficientFundsIn(wallet, command);
+            var wallet = setUpWallet(context());
+            var command = withdrawMoneyFrom(wallet);
+            var expected = insufficientFundsIn(wallet, command);
             context().receivesCommand(command);
 
             context().assertEvent(expected);
@@ -116,9 +103,9 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("emitting the `MoneyReservationCanceled` event")
         void cancelMoneyReservation() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet.getId());
-            MoneyReservationCanceled event = moneyReservationCanceledBy(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = withdrawMoneyFrom(wallet.getId());
+            var event = moneyReservationCanceledBy(command);
             RejectingPaymentProcess.switchToRejectionMode();
             context().receivesCommand(command);
 
@@ -134,12 +121,12 @@ public final class WalletWithdrawalTest extends FreshContextTest {
 
         @Test
         void balance() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney firstWithdraw = withdrawMoneyFrom(wallet.getId());
-            WithdrawMoney secondWithdraw = withdrawMoneyFrom(wallet.getId());
-            WalletBalance expected = walletBalanceReducedBy(firstWithdraw,
-                                                            secondWithdraw,
-                                                            wallet);
+            var wallet = setUpReplenishedWallet(context());
+            var firstWithdraw = withdrawMoneyFrom(wallet.getId());
+            var secondWithdraw = withdrawMoneyFrom(wallet.getId());
+            var expected = walletBalanceReducedBy(firstWithdraw,
+                                                  secondWithdraw,
+                                                  wallet);
             context().receivesCommands(firstWithdraw, secondWithdraw);
 
             context().assertState(wallet.getId(), expected);
@@ -153,9 +140,9 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("with state")
         void entity() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet.getId());
-            WalletWithdrawal expected = walletWithdrawalBy(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = withdrawMoneyFrom(wallet.getId());
+            var expected = walletWithdrawalBy(command);
             context().receivesCommand(command);
 
             context().assertState(command.getWithdrawalProcess(), expected);
@@ -164,9 +151,9 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("which sends the `ReserveMoney` command")
         void reserveMoney() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet.getId());
-            ReserveMoney expected = reserveMoneyWith(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = withdrawMoneyFrom(wallet.getId());
+            var expected = reserveMoneyWith(command);
             context().receivesCommand(command);
 
             context().assertCommands()
@@ -178,10 +165,9 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("which sends the `TransferMoneyToUser` command")
         void transferMoneyToUser() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet.getId());
-            TransferMoneyToUser expected =
-                    transferMoneyToUserWith(command, shareAwareIban);
+            var wallet = setUpReplenishedWallet(context());
+            var command = withdrawMoneyFrom(wallet.getId());
+            var expected = transferMoneyToUserWith(command, shareAwareIban);
             context().receivesCommand(command);
 
             context().assertCommands()
@@ -193,9 +179,9 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("which sends the `DebitReservedMoney` command")
         void debitReservedMoney() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet.getId());
-            DebitReservedMoney expected = debitReservedMoneyWith(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = withdrawMoneyFrom(wallet.getId());
+            var expected = debitReservedMoneyWith(command);
             context().receivesCommand(command);
 
             context().assertCommands()
@@ -207,9 +193,9 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("which emits the `WalletWithdrawn` event and archives itself after it")
         void event() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet.getId());
-            MoneyWithdrawn expected = moneyWithdrawnBy(command, wallet);
+            var wallet = setUpReplenishedWallet(context());
+            var command = withdrawMoneyFrom(wallet.getId());
+            var expected = moneyWithdrawnBy(command, wallet);
             context().receivesCommand(command);
 
             context().assertEvent(expected);
@@ -222,10 +208,10 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("which emits the `WalletNotWithdrawn` event when insufficient funds on the wallet")
         void insufficientFunds() {
-            WalletId wallet = setUpWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet);
-            WithdrawalId withdrawalProcess = command.getWithdrawalProcess();
-            MoneyNotWithdrawn expected = moneyNotWithdrawnBy(withdrawalProcess);
+            var wallet = setUpWallet(context());
+            var command = withdrawMoneyFrom(wallet);
+            var withdrawalProcess = command.getWithdrawalProcess();
+            var expected = moneyNotWithdrawnBy(withdrawalProcess);
             context().receivesCommand(command);
 
             context().assertEvent(expected);
@@ -237,9 +223,9 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("which sends `CancelMoneyReservation` command when something went wrong in payment system")
         void moneyCannotBeTransferredToUser() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet.getId());
-            CancelMoneyReservation expected = cancelMoneyReservationBy(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = withdrawMoneyFrom(wallet.getId());
+            var expected = cancelMoneyReservationBy(command);
             RejectingPaymentProcess.switchToRejectionMode();
             context().receivesCommand(command);
 
@@ -253,10 +239,10 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("which emits the `WalletNotWithdrawn` event when money reservation was canceled")
         void moneyReservationCanceled() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet.getId());
-            WithdrawalId withdrawalProcess = command.getWithdrawalProcess();
-            MoneyNotWithdrawn expected = moneyNotWithdrawnBy(withdrawalProcess);
+            var wallet = setUpReplenishedWallet(context());
+            var command = withdrawMoneyFrom(wallet.getId());
+            var withdrawalProcess = command.getWithdrawalProcess();
+            var expected = moneyNotWithdrawnBy(withdrawalProcess);
             RejectingPaymentProcess.switchToRejectionMode();
             context().receivesCommand(command);
 
@@ -275,9 +261,9 @@ public final class WalletWithdrawalTest extends FreshContextTest {
         @Test
         @DisplayName("which emits the `MoneyTransferredToUser` event")
         void transferMoney() {
-            Wallet wallet = setUpReplenishedWallet(context());
-            WithdrawMoney command = withdrawMoneyFrom(wallet.getId());
-            MoneyTransferredToUser expected = moneyTransferredToUserBy(command);
+            var wallet = setUpReplenishedWallet(context());
+            var command = withdrawMoneyFrom(wallet.getId());
+            var expected = moneyTransferredToUserBy(command);
             context().receivesCommand(command);
 
             context().assertEvent(expected);

--- a/server/src/test/java/io/spine/examples/shareaware/server/watchlist/UserWatchlistsProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/watchlist/UserWatchlistsProjectionTest.java
@@ -37,7 +37,7 @@ import io.spine.testing.server.blackbox.ContextAwareTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.examples.shareaware.watchlist.UserWatchlists.*;
+import static io.spine.examples.shareaware.watchlist.UserWatchlists.WatchlistView;
 
 @DisplayName("`UserWatchlistsProjection` should")
 public final class UserWatchlistsProjectionTest extends ContextAwareTest {
@@ -50,12 +50,12 @@ public final class UserWatchlistsProjectionTest extends ContextAwareTest {
     @Test
     @DisplayName("display all user's watchlists, as soon as they are created")
     void watchlists() {
-        UserId user = GivenUserId.generated();
-        CreateWatchlist firstCommand = generateCommand(user, "first");
-        CreateWatchlist secondCommand = generateCommand(user, "second");
-        WatchlistView firstWatchlist = generateWatchlistView(firstCommand);
-        WatchlistView secondWatchlist = generateWatchlistView(secondCommand);
-        UserWatchlists expected = UserWatchlists
+        var user = GivenUserId.generated();
+        var firstCommand = generateCommand(user, "first");
+        var secondCommand = generateCommand(user, "second");
+        var firstWatchlist = generateWatchlistView(firstCommand);
+        var secondWatchlist = generateWatchlistView(secondCommand);
+        var expected = UserWatchlists
                 .newBuilder()
                 .setId(firstCommand.getUser())
                 .addWatchlist(firstWatchlist)

--- a/server/src/test/java/io/spine/examples/shareaware/server/watchlist/WatchlistTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/watchlist/WatchlistTest.java
@@ -28,12 +28,9 @@ package io.spine.examples.shareaware.server.watchlist;
 
 import io.spine.examples.shareaware.server.TradingContext;
 import io.spine.examples.shareaware.watchlist.Watchlist;
-import io.spine.examples.shareaware.watchlist.command.CreateWatchlist;
-import io.spine.examples.shareaware.watchlist.command.WatchShare;
 import io.spine.examples.shareaware.watchlist.event.ShareWatched;
 import io.spine.examples.shareaware.watchlist.event.WatchlistCreated;
 import io.spine.server.BoundedContextBuilder;
-import io.spine.testing.server.EventSubject;
 import io.spine.testing.server.blackbox.ContextAwareTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -56,18 +53,18 @@ public final class WatchlistTest extends ContextAwareTest {
         @Test
         @DisplayName("and emit the `WatchlistCreated` event")
         void event() {
-            CreateWatchlist command = createWatchlist();
+            var command = createWatchlist();
             context().receivesCommand(command);
-            WatchlistCreated expected = WatchlistCreated
+            var expected = WatchlistCreated
                     .newBuilder()
                     .setOwner(command.getUser())
                     .setWatchlist(command.getWatchlist())
                     .setName(command.getName())
                     .vBuild();
-            EventSubject assertEvents = context()
+            var assertEvents = context()
                     .assertEvents()
                     .withType(WatchlistCreated.class);
-            Watchlist expectedState = Watchlist
+            var expectedState = Watchlist
                     .newBuilder()
                     .setId(command.getWatchlist())
                     .setOwner(command.getUser())
@@ -87,9 +84,9 @@ public final class WatchlistTest extends ContextAwareTest {
         @Test
         @DisplayName("and emit the `ShareWatched` event")
         void event() {
-            Watchlist watchlist = setUpWatchlist(context());
-            WatchShare command = watchShare(watchlist.getId(), watchlist.getOwner());
-            ShareWatched expected = ShareWatched
+            var watchlist = setUpWatchlist(context());
+            var command = watchShare(watchlist.getId(), watchlist.getOwner());
+            var expected = ShareWatched
                     .newBuilder()
                     .setWatchlist(command.getWatchlist())
                     .setShare(command.getShare())
@@ -103,11 +100,11 @@ public final class WatchlistTest extends ContextAwareTest {
         @Test
         @DisplayName("by adding share to watchlist")
         void state() {
-            Watchlist watchlist = setUpWatchlist(context());
-            WatchShare firstCommand = watchShare(watchlist.getId(), watchlist.getOwner());
-            WatchShare secondCommand = watchShare(watchlist.getId(), watchlist.getOwner());
+            var watchlist = setUpWatchlist(context());
+            var firstCommand = watchShare(watchlist.getId(), watchlist.getOwner());
+            var secondCommand = watchShare(watchlist.getId(), watchlist.getOwner());
             context().receivesCommands(firstCommand, secondCommand);
-            Watchlist expected = watchlist
+            var expected = watchlist
                     .toBuilder()
                     .addShare(firstCommand.getShare())
                     .addShare(secondCommand.getShare())


### PR DESCRIPTION
This PR migrates the project to Java 11 from Java 8.  During the migration, all explicit type declarations were replaced by `var` declarations, and the configuration of the libraries was adjusted.