### PR TITLE
Repair warnings about `INT32` fields with `(required)` option

### DIFF
--- a/model/src/main/proto/spine_examples/shareaware/investment/commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/commands.proto
@@ -47,7 +47,7 @@ message AddShares {
     PurchaseId process = 2 [(required) = true];
 
     // The number of shares to add.
-    int32 quantity = 3 [(required) = true];
+    int32 quantity = 3 [(min).value = "1"];
 }
 
 // A command to reserve shares for their sale.
@@ -60,7 +60,7 @@ message ReserveShares {
     SaleId process = 2 [(required) = true];
 
     // The quantity of shares to reserve.
-    int32 quantity = 3 [(required) = true];
+    int32 quantity = 3 [(min).value = "1"];
 }
 
 // A command to complete the shares reservation.

--- a/model/src/main/proto/spine_examples/shareaware/investment/events.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/events.proto
@@ -47,7 +47,7 @@ message SharesAdded {
     PurchaseId process = 2 [(required) = true];
 
     // How many shares are available in the investment.
-    int32 shares_available = 3 [(required) = true];
+    int32 shares_available = 3 [(min).value = "1"];
 }
 
 // Shares have been reserved in the investment.
@@ -60,7 +60,7 @@ message SharesReserved {
     SaleId process = 2 [(required) = true];
 
     // The quantity of shares that was reserved.
-    int32 quantity = 3 [(required) = true];
+    int32 quantity = 3 [(min).value = "1"];
 }
 
 // The shares reservation has been completed.
@@ -73,7 +73,7 @@ message SharesReservationCompleted {
     SaleId process = 2 [(required) = true];
 
     // How many shares are available in the investment.
-    int32 shares_available = 3 [(required) = true];
+    int32 shares_available = 3 [(min).value = "1"];
 }
 
 // The shares reservation has been canceled.

--- a/model/src/main/proto/spine_examples/shareaware/investment/investment.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/investment.proto
@@ -48,7 +48,7 @@ message Investment {
     //
     // Does not include those which are reserved. See `shares_reserved` field.
     //
-    int32 shares_available = 2 [(required) = true];
+    int32 shares_available = 2 [(min).value = "1"];
 
     // The reserved amount of shares per sale operation.
     //

--- a/model/src/main/proto/spine_examples/shareaware/investment/investment_view.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/investment_view.proto
@@ -45,5 +45,5 @@ message InvestmentView {
     InvestmentId id = 1;
 
     // How many shares are available in the investment.
-    int32 shares_available = 2;
+    int32 shares_available = 2 [(min).value = "1"];
 }

--- a/model/src/main/proto/spine_examples/shareaware/investment/purchase_commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/purchase_commands.proto
@@ -53,7 +53,7 @@ message PurchaseShares {
     ShareId share = 3 [(required) = true];
 
     // The quantity of shares to purchase.
-    int32 quantity = 4 [(required) = true];
+    int32 quantity = 4 [(min).value = "1"];
 
     // The price per share at the time of purchase.
     spine.money.Money price = 5 [(required) = true];

--- a/model/src/main/proto/spine_examples/shareaware/investment/purchase_events.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/purchase_events.proto
@@ -51,7 +51,7 @@ message SharesPurchased {
     ShareId share = 3 [(required) = true];
 
     // How many shares are available after the purchase.
-    int32 shares_available = 4 [(required) = true];
+    int32 shares_available = 4 [(min).value = "1"];
 }
 
 // Shares purchase process failed.

--- a/model/src/main/proto/spine_examples/shareaware/investment/rejections.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/rejections.proto
@@ -46,5 +46,5 @@ message InsufficientShares {
     SaleId process = 2 [(required) = true];
 
     // The quantity of shares that initially wanted to be reserved.
-    int32 quantity = 4 [(required) = true];
+    int32 quantity = 4 [(min).value = "1"];
 }

--- a/model/src/main/proto/spine_examples/shareaware/investment/sale_commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/sale_commands.proto
@@ -63,5 +63,5 @@ message SellShares {
     spine.money.Money price = 4 [(required) = true];
 
     // The quantity of shares to sell.
-    int32 quantity = 5 [(required) = true];
+    int32 quantity = 5 [(min).value = "1"];
 }

--- a/model/src/main/proto/spine_examples/shareaware/investment/sale_events.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/sale_events.proto
@@ -55,7 +55,7 @@ message SharesSold {
     spine.money.Money price = 4 [(required) = true];
 
     // How many shares are available after the sell.
-    int32 shares_available = 5 [(required) = true];
+    int32 shares_available = 5 [(min).value = "1"];
 }
 
 // Shares sale process has been failed.

--- a/model/src/main/proto/spine_examples/shareaware/investment/shares_purchase.proto
+++ b/model/src/main/proto/spine_examples/shareaware/investment/shares_purchase.proto
@@ -52,7 +52,7 @@ message SharesPurchase {
     ShareId share = 3 [(required) = true];
 
     // The quantity of shares to purchase.
-    int32 quantity = 4;
+    int32 quantity = 4 [(min).value = "1"];
 
     // How many shares are available after the purchased quantity was added to the investment.
     int32 shares_available = 5;

--- a/model/src/main/proto/spine_examples/shareaware/market/commands.proto
+++ b/model/src/main/proto/spine_examples/shareaware/market/commands.proto
@@ -51,7 +51,7 @@ message ObtainShares {
     ShareId share = 3 [(required) = true];
 
     // The quantity of the shares that the purchase process wants to obtain.
-    int32 quantity = 4 [(required) = true];
+    int32 quantity = 4 [(min).value = "1"];
 }
 
 // A command to sell shares on the market.
@@ -70,7 +70,7 @@ message SellSharesOnMarket {
     spine.money.Money price = 4 [(required) = true];
 
     // The quantity of shares to sell on the market.
-    int32 quantity = 5 [(required) = true];
+    int32 quantity = 5 [(min).value = "1"];
 }
 
 // A command to open the shares market.

--- a/model/src/main/proto/spine_examples/shareaware/market/events.proto
+++ b/model/src/main/proto/spine_examples/shareaware/market/events.proto
@@ -52,7 +52,7 @@ message SharesObtained {
     ShareId share = 3 [(required) = true];
 
     // The quantity of shares that was obtained by the process.
-    int32 quantity = 4 [(required) = true];
+    int32 quantity = 4 [(min).value = "1"];
 }
 
 // Shares have been sold on the market.
@@ -68,7 +68,7 @@ message SharesSoldOnMarket {
     ShareId share = 3 [(required) = true];
 
     // The quantity of the sold shares.
-    int32 quantity = 4 [(required) = true];
+    int32 quantity = 4 [(min).value = "1"];
 
     // The price for which the shares were sold.
     spine.money.Money price = 5 [(required) = true];


### PR DESCRIPTION
This PR repairs warnings in `proto` messages that fields of type `INT32` should not be declared as `(required)`.
Console logging: 
![image](https://user-images.githubusercontent.com/44636928/235991758-dd18e013-3f11-487f-89f2-3d7dbaf9fe75.png)
