### PR TITLE
Fix the problem with the stop of the `MarketDataProvider`

### DIFF
--- a/server/src/main/java/io/spine/examples/shareaware/server/market/MarketDataProvider.java
+++ b/server/src/main/java/io/spine/examples/shareaware/server/market/MarketDataProvider.java
@@ -26,6 +26,8 @@
 
 package io.spine.examples.shareaware.server.market;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.spine.base.EventMessage;
 import io.spine.core.UserId;
 import io.spine.examples.shareaware.market.event.MarketSharesUpdated;
 import io.spine.server.integration.ThirdPartyContext;
@@ -34,10 +36,11 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
-import static java.util.concurrent.TimeUnit.*;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Provides data about currently available shares on the market to the ShareAware context.
@@ -109,12 +112,23 @@ public final class MarketDataProvider {
      * on behalf of the {@value contextName} Bounded Context.
      */
     public synchronized void runWith(Duration period) {
+        runWith(period, (msg) -> {});
+    }
+
+    /**
+     * Emits the {@code MarketSharesUpdated} event with a specified periodicity
+     * on behalf of the {@value contextName} Bounded Context.
+     *
+     * <p>Notifies the specified listener about each event emitted.
+     */
+    public synchronized void runWith(Duration period, Consumer<EventMessage> listener) {
         active.set(true);
         this.period = period;
         marketThread.execute(() -> {
             while (active.get()) {
                 sleepUninterruptibly(period);
-                emitEvent();
+                var msg = emitEvent();
+                listener.accept(msg);
             }
         });
     }
@@ -138,7 +152,8 @@ public final class MarketDataProvider {
         marketThread.awaitTermination(period.toMillis(), MILLISECONDS);
     }
 
-    private void emitEvent() {
+    @CanIgnoreReturnValue
+    private MarketSharesUpdated emitEvent() {
         var updatedShares = MarketData.actualShares();
         var event = MarketSharesUpdated
                 .newBuilder()
@@ -146,5 +161,6 @@ public final class MarketDataProvider {
                 .addAllShare(updatedShares)
                 .vBuild();
         marketContext.emittedEvent(event, actor);
+        return event;
     }
 }

--- a/server/src/test/java/io/spine/examples/shareaware/server/e2e/given/WithServer.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/e2e/given/WithServer.java
@@ -51,7 +51,7 @@ public abstract class WithServer {
     private static final String ADDRESS = "localhost";
     private static final int PORT = 4242;
     private Server server;
-    private static final Collection<ManagedChannel> channels = new ArrayList<>();
+    private final Collection<ManagedChannel> channels = new ArrayList<>();
     private static final MarketDataProvider provider = MarketDataProvider.instance();
 
     /**

--- a/server/src/test/java/io/spine/examples/shareaware/server/e2e/given/WithServer.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/e2e/given/WithServer.java
@@ -30,8 +30,8 @@ import io.grpc.ManagedChannel;
 import io.spine.examples.shareaware.server.TradingContext;
 import io.spine.examples.shareaware.server.market.MarketDataProvider;
 import io.spine.server.Server;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -50,17 +50,18 @@ public abstract class WithServer {
 
     private static final String ADDRESS = "localhost";
     private static final int PORT = 4242;
-    private static final Server server = atPort(PORT)
-            .add(TradingContext.newBuilder())
-            .build();
+    private Server server;
     private static final Collection<ManagedChannel> channels = new ArrayList<>();
     private static final MarketDataProvider provider = MarketDataProvider.instance();
 
     /**
      * Starts the server and runs the {@link MarketDataProvider}.
      */
-    @BeforeAll
-    static void startProvider() throws IOException {
+    @BeforeEach
+    void startAndConnect() throws IOException {
+        server = atPort(PORT)
+                .add(TradingContext.newBuilder())
+                .build();
         server.start();
         provider.runWith(Duration.ofSeconds(1));
     }
@@ -68,8 +69,8 @@ public abstract class WithServer {
     /**
      * Shuts the server, all channels, and {@link MarketDataProvider} down.
      */
-    @AfterAll
-    static void stopProvider() {
+    @AfterEach
+    void stopAndDisconnect() {
         provider.stopEmission();
         server.shutdown();
         channels.forEach(WithServer::closeChannel);

--- a/server/src/test/java/io/spine/examples/shareaware/server/market/MarketDataProviderTest.java
+++ b/server/src/test/java/io/spine/examples/shareaware/server/market/MarketDataProviderTest.java
@@ -26,6 +26,7 @@
 
 package io.spine.examples.shareaware.server.market;
 
+import io.spine.base.EventMessage;
 import io.spine.examples.shareaware.market.event.MarketSharesUpdated;
 import io.spine.examples.shareaware.server.FreshContextTest;
 import io.spine.examples.shareaware.server.market.given.MarketTestContext;
@@ -34,8 +35,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.Collections.synchronizedList;
 
 @DisplayName("`MarketDataService` should")
 final class MarketDataProviderTest extends FreshContextTest {
@@ -48,15 +52,16 @@ final class MarketDataProviderTest extends FreshContextTest {
     }
 
     @Test
-    @DisplayName("emit two `MarketSharesUpdated` events in two point five seconds")
-    void emitEvent() throws InterruptedException {
-        service.runWith(Duration.ofSeconds(1));
+    @DisplayName("emit expected number of `MarketSharesUpdated` events " +
+            "with respect to emission interval")
+    void emitEvent() {
+        List<EventMessage> emitted = synchronizedList(new ArrayList<>());
+        service.runWith(Duration.ofSeconds(1), emitted::add);
         sleepUninterruptibly(Duration.ofMillis(2500));
+        service.stopEmission();
 
         context().assertEvents()
                  .withType(MarketSharesUpdated.class)
-                 .hasSize(2);
-
-        service.stopEmission();
+                 .hasSize(emitted.size());
     }
 }


### PR DESCRIPTION
This PR fixes the problem with the stop of the `MarketDataProvider`, that occurred by the specificity of the `SingleThreadExecutor` work that we use for event emission. Unlike the previous implementation, we provide waiting for `SingleThreadExecutor` to finish all tasks accumulated for execution before stopping the event emission.
Also, this PR modifies the `FreshContextTest` to reset the `Delivery`. We need this modification because many test actions happen asynchronously, so we bind the delivery operations to the scope of their respective test method.